### PR TITLE
Added custom http response messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ of-watchdog
 nodejs-afterburn
 faster
 of-watchdog*
+
+# Common tempprary files
+\#*
+*~
+*.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,13 @@ FROM golang:1.9.1
 RUN mkdir -p /go/src/github.com/openfaas-incubator/of-watchdog
 WORKDIR /go/src/github.com/openfaas-incubator/of-watchdog
 
+# Get dependencies
+RUN go get github.com/satori/go.uuid
+
 COPY main.go    .
 COPY config     config
 COPY functions  functions
+COPY utilities  utilities
 
 # Run a gofmt and exclude all vendored code.
 RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))"

--- a/README.md
+++ b/README.md
@@ -11,9 +11,22 @@ Watchdog modes:
 
 Forks a process per request and can deal with more data than is available memory capacity - i.e. 512mb VM can process multiple GB of video.
 
-HTTP headers cannot be sent after function starts executing due to input/output being hooked-up directly to response for streaming efficiencies. Response code is always 200 unless there is an issue forking the process. An error mid-flight will have to be picked up on the client. Multi-threaded.
+HTTP headers and response code can be set by writing JSON to the file
+specified in the `CONTROL_PIPE` environment variable. This data must be
+sent before anything is written to stdout by the called process. This
+can be used to send any headers or any response code. The format for the
+json is as follows:
 
-A static Content-type can be set ahead of time.
+```
+{
+  "status": 200,
+  "headers": {
+    "Content-Type": "application/json"
+  }
+}
+```
+
+This runs multi-threaded.
 
 Hard timeout: supported.
 

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -15,6 +16,7 @@ type WatchdogConfig struct {
 	InjectCGIHeaders bool
 	HardTimeout      time.Duration
 	OperationalMode  int
+	TempDirectory    string
 }
 
 func (w WatchdogConfig) Process() (string, []string) {
@@ -36,11 +38,19 @@ func New(env []string) (WatchdogConfig, error) {
 		InjectCGIHeaders: true,
 		HardTimeout:      5 * time.Second,
 		OperationalMode:  ModeStreaming,
+		TempDirectory:    os.TempDir(),
 	}
 
 	envMap := mapEnv(env)
 	if val := envMap["mode"]; len(val) > 0 {
 		config.OperationalMode = WatchdogModeConst(val)
+	}
+
+	// Try to make a subdir, otherwise use the global tmpdir
+	dir, err := ioutil.TempDir(os.TempDir(), "")
+	fmt.Println(err)
+	if err == nil {
+		config.TempDirectory = dir
 	}
 
 	return config, nil

--- a/main.go
+++ b/main.go
@@ -5,10 +5,15 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/openfaas-incubator/of-watchdog/config"
 	"github.com/openfaas-incubator/of-watchdog/functions"
+	"github.com/openfaas-incubator/of-watchdog/utilities"
+
+	// For generating unique names for the pipes
+	"github.com/satori/go.uuid"
 )
 
 func main() {
@@ -126,12 +131,18 @@ func makeForkRequestHandler(watchdogConfig config.WatchdogConfig) func(http.Resp
 			environment = getEnvironment(r)
 		}
 
+		u, _ := uuid.NewV4()
+		pipeName := filepath.Join(watchdogConfig.TempDirectory, u.String())
+		utilities.CreatePipeIfNotExists(pipeName)
+		environment = append(environment, fmt.Sprintf("CONTROL_PIPE=%s", pipeName))
+		sw := utilities.NewShim(w, pipeName)
+
 		commandName, arguments := watchdogConfig.Process()
 		req := functions.FunctionRequest{
 			Process:      commandName,
 			ProcessArgs:  arguments,
 			InputReader:  r.Body,
-			OutputWriter: w,
+			OutputWriter: sw,
 			Environment:  environment,
 		}
 
@@ -140,6 +151,7 @@ func makeForkRequestHandler(watchdogConfig config.WatchdogConfig) func(http.Resp
 			w.WriteHeader(500)
 			w.Write([]byte(err.Error()))
 		}
+		os.Remove(pipeName)
 	}
 }
 

--- a/utilities/ShimWriter.go
+++ b/utilities/ShimWriter.go
@@ -1,0 +1,51 @@
+package utilities
+
+import (
+	"net/http"
+)
+
+type shimWriter struct {
+	Nested http.ResponseWriter
+	controlChan chan HTTPControl
+	dirty bool
+}
+
+func NewShim(nest http.ResponseWriter, control string) http.ResponseWriter {
+	ch := make(chan HTTPControl)
+	go ReadFromPipe(control, ch)
+	return shimWriter{nest, ch, false}
+}
+
+func (s shimWriter) Header() http.Header {
+	return s.Nested.Header()
+}
+
+func (s shimWriter) WriteHeader(rc int) {
+	s.dirty = true
+	s.Nested.WriteHeader(rc)
+}
+
+func (s shimWriter) Write(bytes []byte) (int, error) {
+
+	if s.dirty == false {
+		select {
+		case controlMessage := <-s.controlChan:
+			// Write headers from the control message
+			headers := s.Header()
+			for key, value := range controlMessage.Headers {
+				headers.Set(key, value)
+			}
+			if controlMessage.Status != 0 {
+				s.WriteHeader(controlMessage.Status)
+			} else {
+				s.WriteHeader(200)
+			}
+		default:
+			// If nothing was sent yet, explicitely send a 200 header
+			s.WriteHeader(200)
+		}
+		s.dirty = true
+	}
+
+	return s.Nested.Write(bytes)
+}

--- a/utilities/utilities.go
+++ b/utilities/utilities.go
@@ -1,0 +1,39 @@
+package utilities
+
+import (
+	"io/ioutil"
+	"os"
+	"syscall"
+	"encoding/json"
+)
+
+type HTTPControl struct{
+	Status int `json:status`
+	Headers map[string]string `json:headers`
+}
+
+func createPipe(path string) {
+	oldmask := syscall.Umask(000)
+	syscall.Mkfifo(path, 0666)
+	syscall.Umask(oldmask)
+}
+func CreatePipeIfNotExists(path string) {
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		createPipe(path)
+	}
+}
+
+func ReadFromPipe(path string, c chan<- HTTPControl) {
+	pipe, err := os.Open(path)
+	if err == nil {
+		s, err := ioutil.ReadAll(pipe)
+		if err == nil {
+			control := HTTPControl{}
+			err = json.Unmarshal(s, &control)
+			if err == nil{
+				c <- control
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR includes code which allows controlled processes to feed back http control messages for the status code and headers to the controlling watchdog for sending back to the client when using the streaming mode.

This allows programs to send any response code, headers, content type, and the like to each individual response.