### PR TITLE
Change hard timeout to exec timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ HTTP headers cannot be sent after function starts executing due to input/output 
 
 * A static Content-type can be set ahead of time.
 
-* Hard timeout: supported.
+* Exec timeout: supported.
 
 ### 2. Afterburn (mode=afterburn)
 
@@ -40,7 +40,7 @@ Vastly accelerated processing speed but requires a client library for each langu
 
 * A dynamic Content-type can be set from the client library.
 
-* Hard timeout: not supported.
+* Exec timeout: not supported.
 
 Example client libraries:
 
@@ -98,7 +98,7 @@ Reads entire request into memory from the HTTP request. At this point we seriali
 
 * A static Content-type can be set ahead of time.
 
-* Hard timeout: supported.
+* Exec timeout: supported.
 
 ## Configuration
 
@@ -109,7 +109,7 @@ Environmental variables:
 | `function_process`     | Yes          | The process to invoke for each function call function process (alias - fprocess). This must be a UNIX binary and accept input via STDIN and output via STDOUT.  |
 | `read_timeout`         | Yes          | HTTP timeout for reading the payload from the client caller (in seconds) |
 | `write_timeout`        | Yes          | HTTP timeout for writing a response body from your function (in seconds)  |
-| `hard_timeout`         | Yes          | Hard timeout for process exec'd for each incoming request (in seconds). Disabled if set to 0. |
+| `exec_timeout`         | Yes          | Exec timeout for process exec'd for each incoming request (in seconds). Disabled if set to 0. |
 | `port`                 | Yes          | Specify an alternative TCP port fo testing |
 | `write_debug`          | No           | Write all output, error messages, and additional information to the logs. Default is false. |
 | `content_type`         | Yes          | Force a specific Content-Type response for all responses - only in forking/serializing modes. |

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,7 @@ type WatchdogConfig struct {
 	TCPPort          int
 	HTTPReadTimeout  time.Duration
 	HTTPWriteTimeout time.Duration
-	HardTimeout      time.Duration
+	ExecTimeout      time.Duration
 
 	FunctionProcess  string
 	ContentType      string
@@ -56,7 +56,7 @@ func New(env []string) (WatchdogConfig, error) {
 		HTTPWriteTimeout: getDuration(envMap, "write_timeout", time.Second*10),
 		FunctionProcess:  functionProcess,
 		InjectCGIHeaders: true,
-		HardTimeout:      getDuration(envMap, "hard_timeout", time.Second*10),
+		ExecTimeout:      getDuration(envMap, "exec_timeout", time.Second*10),
 		OperationalMode:  ModeStreaming,
 		ContentType:      contentType,
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -108,7 +108,7 @@ func Test_PortOverride(t *testing.T) {
 	}
 
 	if actual.TCPPort != 8081 {
-		t.Errorf("Want %s. got: %s", 8081, actual.TCPPort)
+		t.Errorf("Want %d. got: %d", 8081, actual.TCPPort)
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -116,7 +116,7 @@ func Test_Timeouts(t *testing.T) {
 	cases := []struct {
 		readTimeout  time.Duration
 		writeTimeout time.Duration
-		hardTimeout  time.Duration
+		execTimeout  time.Duration
 		env          []string
 		name         string
 	}{
@@ -124,29 +124,29 @@ func Test_Timeouts(t *testing.T) {
 			name:         "Defaults",
 			readTimeout:  time.Second * 10,
 			writeTimeout: time.Second * 10,
-			hardTimeout:  time.Second * 10,
+			execTimeout:  time.Second * 10,
 			env:          []string{},
 		},
 		{
 			name:         "Custom read-timeout",
 			readTimeout:  time.Second * 5,
 			writeTimeout: time.Second * 10,
-			hardTimeout:  time.Second * 10,
+			execTimeout:  time.Second * 10,
 			env:          []string{"read_timeout=5s"},
 		},
 		{
 			name:         "Custom write-timeout",
 			readTimeout:  time.Second * 10,
 			writeTimeout: time.Second * 5,
-			hardTimeout:  time.Second * 10,
+			execTimeout:  time.Second * 10,
 			env:          []string{"write_timeout=5s"},
 		},
 		{
-			name:         "Custom hard-timeout",
+			name:         "Custom exec-timeout",
 			readTimeout:  time.Second * 10,
 			writeTimeout: time.Second * 10,
-			hardTimeout:  time.Second * 5,
-			env:          []string{"hard_timeout=5s"},
+			execTimeout:  time.Second * 5,
+			env:          []string{"exec_timeout=5s"},
 		},
 	}
 
@@ -161,8 +161,8 @@ func Test_Timeouts(t *testing.T) {
 		if testCase.writeTimeout != actual.HTTPWriteTimeout {
 			t.Errorf("(%s) HTTPWriteTimeout want: %s, got: %s", testCase.name, actual.HTTPWriteTimeout, testCase.writeTimeout)
 		}
-		if testCase.hardTimeout != actual.HardTimeout {
-			t.Errorf("(%s) HardTimeout want: %s, got: %s", testCase.name, actual.HardTimeout, testCase.hardTimeout)
+		if testCase.execTimeout != actual.ExecTimeout {
+			t.Errorf("(%s) ExecTimeout want: %s, got: %s", testCase.name, actual.ExecTimeout, testCase.execTimeout)
 		}
 
 	}

--- a/functions/serializing_fork_runner.go
+++ b/functions/serializing_fork_runner.go
@@ -12,7 +12,7 @@ import (
 
 // SerializingForkFunctionRunner forks a process for each invocation
 type SerializingForkFunctionRunner struct {
-	HardTimeout time.Duration
+	ExecTimeout time.Duration
 }
 
 // Run run a fork for each invocation
@@ -43,17 +43,17 @@ func serializeFunction(req FunctionRequest, f *SerializingForkFunctionRunner) (*
 	cmd.Env = req.Environment
 
 	var timer *time.Timer
-	if f.HardTimeout > time.Millisecond*0 {
+	if f.ExecTimeout > time.Millisecond*0 {
 		log.Println("Started a timer.")
 
-		timer = time.NewTimer(f.HardTimeout)
+		timer = time.NewTimer(f.ExecTimeout)
 		go func() {
 			<-timer.C
 
-			log.Printf("Function was killed by HardTimeout: %s\n", f.HardTimeout)
+			log.Printf("Function was killed by ExecTimeout: %s\n", f.ExecTimeout)
 			killErr := cmd.Process.Kill()
 			if killErr != nil {
-				log.Println("Error killing function due to HardTimeout", killErr)
+				log.Println("Error killing function due to ExecTimeout", killErr)
 			}
 		}()
 	}

--- a/functions/streaming_runner.go
+++ b/functions/streaming_runner.go
@@ -26,7 +26,7 @@ type FunctionRequest struct {
 
 // ForkFunctionRunner forks a process for each invocation
 type ForkFunctionRunner struct {
-	HardTimeout time.Duration
+	ExecTimeout time.Duration
 }
 
 // Run run a fork for each invocation
@@ -37,16 +37,16 @@ func (f *ForkFunctionRunner) Run(req FunctionRequest) error {
 	cmd.Env = req.Environment
 
 	var timer *time.Timer
-	if f.HardTimeout > time.Millisecond*0 {
-		timer = time.NewTimer(f.HardTimeout)
+	if f.ExecTimeout > time.Millisecond*0 {
+		timer = time.NewTimer(f.ExecTimeout)
 
 		go func() {
 			<-timer.C
 
-			fmt.Printf("Function was killed by HardTimeout: %d\n", f.HardTimeout)
+			fmt.Printf("Function was killed by ExecTimeout: %d\n", f.ExecTimeout)
 			killErr := cmd.Process.Kill()
 			if killErr != nil {
-				fmt.Println("Error killing function due to HardTimeout", killErr)
+				fmt.Println("Error killing function due to ExecTimeout", killErr)
 			}
 		}()
 	}

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func makeAfterBurnRequestHandler(watchdogConfig config.WatchdogConfig) func(http
 
 func makeSerializingForkRequestHandler(watchdogConfig config.WatchdogConfig) func(http.ResponseWriter, *http.Request) {
 	functionInvoker := functions.SerializingForkFunctionRunner{
-		HardTimeout: watchdogConfig.HardTimeout,
+		ExecTimeout: watchdogConfig.ExecTimeout,
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -141,7 +141,7 @@ func makeSerializingForkRequestHandler(watchdogConfig config.WatchdogConfig) fun
 
 func makeForkRequestHandler(watchdogConfig config.WatchdogConfig) func(http.ResponseWriter, *http.Request) {
 	functionInvoker := functions.ForkFunctionRunner{
-		HardTimeout: watchdogConfig.HardTimeout,
+		ExecTimeout: watchdogConfig.ExecTimeout,
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR updates all references to a Hard timeout, replacing it with Exec timeout for consistency with the existing Watchdog where `exec_timeout` is used.

It also fixes a minor issue in the config test where an incorrect format string was being used.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change (have discussed the change directly with @alexellis)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
