### PR TITLE
Enable exec_timeout for http mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM golang:1.9.1
+FROM golang:1.9.4
+
 RUN mkdir -p /go/src/github.com/openfaas-incubator/of-watchdog
 WORKDIR /go/src/github.com/openfaas-incubator/of-watchdog
 
 COPY main.go    .
 COPY config     config
-COPY functions  functions
+COPY executor   executor
 
 # Run a gofmt and exclude all vendored code.
 RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))"

--- a/executor/afterburn_runner.go
+++ b/executor/afterburn_runner.go
@@ -1,4 +1,4 @@
-package functions
+package executor
 
 import (
 	"bufio"

--- a/executor/http_runner.go
+++ b/executor/http_runner.go
@@ -1,4 +1,4 @@
-package functions
+package executor
 
 import (
 	"io"

--- a/executor/serializing_fork_runner.go
+++ b/executor/serializing_fork_runner.go
@@ -1,4 +1,4 @@
-package functions
+package executor
 
 import (
 	"io"
@@ -44,19 +44,19 @@ func serializeFunction(req FunctionRequest, f *SerializingForkFunctionRunner) (*
 
 	var timer *time.Timer
 	if f.ExecTimeout > time.Millisecond*0 {
-		log.Println("Started a timer.")
 
 		timer = time.NewTimer(f.ExecTimeout)
 		go func() {
 			<-timer.C
 
-			log.Printf("Function was killed by ExecTimeout: %s\n", f.ExecTimeout)
+			log.Printf("Function was killed by ExecTimeout: %s\n", f.ExecTimeout.String())
 			killErr := cmd.Process.Kill()
 			if killErr != nil {
 				log.Println("Error killing function due to ExecTimeout", killErr)
 			}
 		}()
 	}
+
 	if timer != nil {
 		defer timer.Stop()
 	}

--- a/executor/streaming_runner.go
+++ b/executor/streaming_runner.go
@@ -1,4 +1,4 @@
-package functions
+package executor
 
 import (
 	"fmt"
@@ -43,12 +43,16 @@ func (f *ForkFunctionRunner) Run(req FunctionRequest) error {
 		go func() {
 			<-timer.C
 
-			fmt.Printf("Function was killed by ExecTimeout: %d\n", f.ExecTimeout)
+			log.Printf("Function was killed by ExecTimeout: %s\n", f.ExecTimeout.String())
 			killErr := cmd.Process.Kill()
 			if killErr != nil {
 				fmt.Println("Error killing function due to ExecTimeout", killErr)
 			}
 		}()
+	}
+
+	if timer != nil {
+		defer timer.Stop()
 	}
 
 	if req.InputReader != nil {

--- a/main.go
+++ b/main.go
@@ -197,6 +197,7 @@ func getEnvironment(r *http.Request) []string {
 func makeHTTPRequestHandler(watchdogConfig config.WatchdogConfig) func(http.ResponseWriter, *http.Request) {
 	commandName, arguments := watchdogConfig.Process()
 	functionInvoker := executor.HTTPFunctionRunner{
+		ExecTimeout: watchdogConfig.ExecTimeout,
 		Process:     commandName,
 		ProcessArgs: arguments,
 	}

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/openfaas-incubator/of-watchdog/config"
-	"github.com/openfaas-incubator/of-watchdog/functions"
+	"github.com/openfaas-incubator/of-watchdog/executor"
 )
 
 func main() {
@@ -78,7 +78,7 @@ func lock() error {
 func makeAfterBurnRequestHandler(watchdogConfig config.WatchdogConfig) func(http.ResponseWriter, *http.Request) {
 
 	commandName, arguments := watchdogConfig.Process()
-	functionInvoker := functions.AfterBurnFunctionRunner{
+	functionInvoker := executor.AfterBurnFunctionRunner{
 		Process:     commandName,
 		ProcessArgs: arguments,
 	}
@@ -88,7 +88,7 @@ func makeAfterBurnRequestHandler(watchdogConfig config.WatchdogConfig) func(http
 
 	return func(w http.ResponseWriter, r *http.Request) {
 
-		req := functions.FunctionRequest{
+		req := executor.FunctionRequest{
 			Process:      commandName,
 			ProcessArgs:  arguments,
 			InputReader:  r.Body,
@@ -109,7 +109,7 @@ func makeAfterBurnRequestHandler(watchdogConfig config.WatchdogConfig) func(http
 }
 
 func makeSerializingForkRequestHandler(watchdogConfig config.WatchdogConfig) func(http.ResponseWriter, *http.Request) {
-	functionInvoker := functions.SerializingForkFunctionRunner{
+	functionInvoker := executor.SerializingForkFunctionRunner{
 		ExecTimeout: watchdogConfig.ExecTimeout,
 	}
 
@@ -122,7 +122,7 @@ func makeSerializingForkRequestHandler(watchdogConfig config.WatchdogConfig) fun
 		}
 
 		commandName, arguments := watchdogConfig.Process()
-		req := functions.FunctionRequest{
+		req := executor.FunctionRequest{
 			Process:       commandName,
 			ProcessArgs:   arguments,
 			InputReader:   r.Body,
@@ -140,7 +140,7 @@ func makeSerializingForkRequestHandler(watchdogConfig config.WatchdogConfig) fun
 }
 
 func makeForkRequestHandler(watchdogConfig config.WatchdogConfig) func(http.ResponseWriter, *http.Request) {
-	functionInvoker := functions.ForkFunctionRunner{
+	functionInvoker := executor.ForkFunctionRunner{
 		ExecTimeout: watchdogConfig.ExecTimeout,
 	}
 
@@ -153,7 +153,7 @@ func makeForkRequestHandler(watchdogConfig config.WatchdogConfig) func(http.Resp
 		}
 
 		commandName, arguments := watchdogConfig.Process()
-		req := functions.FunctionRequest{
+		req := executor.FunctionRequest{
 			Process:      commandName,
 			ProcessArgs:  arguments,
 			InputReader:  r.Body,
@@ -196,7 +196,7 @@ func getEnvironment(r *http.Request) []string {
 
 func makeHTTPRequestHandler(watchdogConfig config.WatchdogConfig) func(http.ResponseWriter, *http.Request) {
 	commandName, arguments := watchdogConfig.Process()
-	functionInvoker := functions.HTTPFunctionRunner{
+	functionInvoker := executor.HTTPFunctionRunner{
 		Process:     commandName,
 		ProcessArgs: arguments,
 	}
@@ -206,7 +206,7 @@ func makeHTTPRequestHandler(watchdogConfig config.WatchdogConfig) func(http.Resp
 
 	return func(w http.ResponseWriter, r *http.Request) {
 
-		req := functions.FunctionRequest{
+		req := executor.FunctionRequest{
 			Process:      commandName,
 			ProcessArgs:  arguments,
 			InputReader:  r.Body,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Enable exec_timeout for http mode

## Motivation and Context

This needed to be added to the http mode to control the duration of http requests

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally with Go outside of a container with a go function that sleeps within the timeout and beyond it to see that the error is given as Gateway timed out.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.