### PR TITLE
Add /_/health endpoint to of-watchdog

### DIFF
--- a/requesthandler_test.go
+++ b/requesthandler_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHealthHandler_StatusOK_LockFilePresent(t *testing.T) {
+	rr := httptest.NewRecorder()
+
+	present := lockFilePresent()
+
+	if present == false {
+		if err := lock(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "/_/health", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := makeHealthHandler()
+	handler(rr, req)
+
+	required := http.StatusOK
+	if status := rr.Code; status != required {
+		t.Errorf("handler returned wrong status code - want: %v, got: %v", required, status)
+	}
+
+}
+
+func TestHealthHandler_StatusInternalServerError_LockFileNotPresent(t *testing.T) {
+	rr := httptest.NewRecorder()
+
+	if lockFilePresent() == true {
+		if err := removeLockFile(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "/_/health", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := makeHealthHandler()
+	handler(rr, req)
+
+	required := http.StatusInternalServerError
+	if status := rr.Code; status != required {
+		t.Errorf("handler returned wrong status code - want: %v, got: %v", required, status)
+	}
+}
+
+func TestHealthHandler_StatusMethodNotAllowed_ForWriteableVerbs(t *testing.T) {
+	rr := httptest.NewRecorder()
+
+	verbs := []string{http.MethodPost, http.MethodPut, http.MethodDelete}
+
+	for _, verb := range verbs {
+		req, err := http.NewRequest(verb, "/_/health", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		handler := makeHealthHandler()
+		handler(rr, req)
+
+		required := http.StatusMethodNotAllowed
+		if status := rr.Code; status != required {
+			t.Errorf("handler returned wrong status code -  want: %v, got: %v", required, status)
+		}
+	}
+}
+
+func removeLockFile() error {
+	path := filepath.Join(os.TempDir(), ".lock")
+	removeErr := os.Remove(path)
+	return removeErr
+}


### PR DESCRIPTION
Introduce new endpoint `/_/health` to watchdog for health status of
functions which checks for `/tmp/.lock` file

Added tests for healthHandler

Issues: https://github.com/openfaas/faas/issues/547

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
  Issue raised by Alex: https://github.com/openfaas/faas/issues/547


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This has been tested on Mac by building the watchdog binary. 
```
curl -i http://localhost:8081/_/health
HTTP/1.1 200 OK
Date: Tue, 03 Apr 2018 03:51:24 GMT
Content-Length: 2
Content-Type: text/plain; charset=utf-8

OK%
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
