### PR TITLE
Return 500 on non-zero exit status for Serializing and Streaming modes

### DIFF
--- a/executor/serializing_fork_runner.go
+++ b/executor/serializing_fork_runner.go
@@ -92,7 +92,7 @@ func serializeFunction(req FunctionRequest, f *SerializingForkFunctionRunner) (*
 
 	waitErr := cmd.Wait()
 	if waitErr != nil {
-		return nil, err
+		return nil, waitErr
 	}
 
 	done := time.Since(start)

--- a/main.go
+++ b/main.go
@@ -166,9 +166,8 @@ func makeForkRequestHandler(watchdogConfig config.WatchdogConfig) func(http.Resp
 		if err != nil {
 			log.Println(err.Error())
 
-			// Probably cannot write to client if we already have written a header
-			// w.WriteHeader(500)
-			// w.Write([]byte(err.Error()))
+			w.WriteHeader(500)
+			w.Write([]byte(err.Error()))
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Eric Stoekl <ems5311@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR is to bubble up non-zero exit code from the fprocess that is run by the `of-watchdog` as a 500 ISE response to the client which invokes the watchdog.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
https://github.com/openfaas-incubator/of-watchdog/issues/12

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Start the watchdog server with `port=8081 mode=serializing fprocess="stat x" ./of-watchdog`

Before the update, when you `curl` the endpoint it will return 200 OK despite the `fprocess` command failing.

```
$ curl localhost:8081 -i
HTTP/1.1 200 OK
Content-Type: application/octet-stream
Date: Wed, 04 Apr 2018 14:48:20 GMT
Content-Length: 0
```

After update, it will return `500` if the `fprocess` command return non-zero:

```
$ curl localhost:8081 -i
HTTP/1.1 500 Internal Server Error
Content-Type: application/octet-stream
Date: Wed, 04 Apr 2018 15:11:24 GMT
Content-Length: 13
```

When running with a working fprocess (use `pwd` for the `fprocess` variable for example) I get a `200` response:

```
$ curl localhost:8081 -i
HTTP/1.1 200 OK
Content-Type: application/octet-stream
Date: Wed, 04 Apr 2018 15:16:00 GMT
Content-Length: 64

/home/s/github/go/src/github.com/openfaas-incubator/of-watchdog
```

You will see the same results with the `streaming` (fork) mode.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
