### PR TITLE
Implement proposal 716, passing full paths through of-watchdog

### DIFF
--- a/executor/http_runner.go
+++ b/executor/http_runner.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"regexp"
 	"sync"
 	"time"
 )
@@ -99,13 +98,8 @@ func (f *HTTPFunctionRunner) Run(req FunctionRequest, contentLength int64, r *ht
 
 	upstreamURL := f.UpstreamURL.String()
 
-	matcher, _ := regexp.Compile("/?function/([^/?]+)(.*)")
-	parts := matcher.FindStringSubmatch(r.RequestURI)
-
-	// The first is the original string, the second the function name
-	// and the third anything else on the path, including the query string
-	if 3 == len(parts) {
-		upstreamURL += parts[2]
+	if len(r.RequestURI) > 0 {
+		upstreamURL += r.RequestURI
 	}
 
 	request, _ := http.NewRequest(r.Method, upstreamURL, r.Body)

--- a/executor/http_runner.go
+++ b/executor/http_runner.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"regexp"
 	"sync"
 	"time"
 )
@@ -98,8 +99,13 @@ func (f *HTTPFunctionRunner) Run(req FunctionRequest, contentLength int64, r *ht
 
 	upstreamURL := f.UpstreamURL.String()
 
-	if len(r.URL.RawQuery) > 0 {
-		upstreamURL += "?" + r.URL.RawQuery
+	matcher, _ := regexp.Compile("/?function/([^/?]+)(.*)")
+	parts := matcher.FindStringSubmatch(r.RequestURI)
+
+	// The first is the original string, the second the function name
+	// and the third anything else on the path, including the query string
+	if 3 == len(parts) {
+		upstreamURL += parts[2]
 	}
 
 	request, _ := http.NewRequest(r.Method, upstreamURL, r.Body)


### PR DESCRIPTION
An implementation of proposal #716, passing the full URL through the of-watchdog.

## Description

Previous to these changes, only the query string provide by the HTTP client was passed through to the handling code.  With these changes, the full URL path is passed as well as the query string.

## Motivation and Context
- [X] I have raised an issue to propose this change

Proposal #716 

## How Has This Been Tested?

Manually.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

Some of the templates have baked in routes of '/' (cf. the node8 template).  Those will also need updated.  The easiest will be to replace the explicit '/' route with a catchall:

```
-app.post('/', middleware);
-app.get('/', middleware);
+app.post('/*', middleware);
+app.get('/*', middleware);
```

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

This may or may not require a documentation change.  The existing documentation, AFAIK, does not address the use of paths one way or the other.

## Refs

Trello: https://trello.com/c/1qZMlGXU