### PR TITLE
Propagate Host header from incoming request to the function.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+language: minimal
 services:
 - docker
 addons:

--- a/build.sh
+++ b/build.sh
@@ -7,9 +7,9 @@ if [ ! "$arch" = "x86_64" ] ; then
     exit 1
 fi
 
-if [ ! $http_proxy == "" ] 
+if [ ! "$http_proxy" = "" ]
 then
-    docker build --no-cache --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -t functions/of-watchdog:build .
+    docker build --no-cache --build-arg "https_proxy=$https_proxy" --build-arg "http_proxy=$http_proxy" -t functions/of-watchdog:build .
 else
     docker build -t functions/of-watchdog:build .
 fi
@@ -23,4 +23,3 @@ docker cp buildoutput:/go/src/github.com/openfaas-incubator/of-watchdog/of-watch
 docker cp buildoutput:/go/src/github.com/openfaas-incubator/of-watchdog/of-watchdog.exe ./of-watchdog.exe
 
 docker rm buildoutput
-

--- a/executor/http_runner.go
+++ b/executor/http_runner.go
@@ -107,6 +107,7 @@ func (f *HTTPFunctionRunner) Run(req FunctionRequest, contentLength int64, r *ht
 		request.Header.Set(h, r.Header.Get(h))
 	}
 
+	request.Host = r.Host
 	copyHeaders(request.Header, &r.Header)
 
 	ctx, cancel := context.WithTimeout(context.Background(), f.ExecTimeout)


### PR DESCRIPTION
Host HTTP header was not propagated to the function because it is not
a part of http.Request.Header map.

Signed-off-by: Dmitri Rubinstein <dmitri.rubinstein@googlemail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
