### PR TITLE
Implement graceful shutdown as per classic watchdog 0.9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ Environmental variables:
 | `read_timeout`         | Yes          | HTTP timeout for reading the payload from the client caller (in seconds) |
 | `write_timeout`        | Yes          | HTTP timeout for writing a response body from your function (in seconds)  |
 | `exec_timeout`         | Yes          | Exec timeout for process exec'd for each incoming request (in seconds). Disabled if set to 0. |
-| `port`                 | Yes          | Specify an alternative TCP port fo testing |
+| `port`                 | Yes          | Specify an alternative TCP port for testing |
 | `write_debug`          | No           | Write all output, error messages, and additional information to the logs. Default is false. |
 | `content_type`         | Yes          | Force a specific Content-Type response for all responses - only in forking/serializing modes. |
-| `suppress_lock`        | No           | The watchdog will attempt to write a lockfile to /tmp/ for swarm healthchecks - set this to true to disable behaviour. |
+| `suppress_lock`        | Yes           | The watchdog will attempt to write a lockfile to /tmp/ for swarm healthchecks - set this to true to disable behaviour. |
 | `upstream_url`         | Yes          | `http` mode only - where to forward requests i.e. 127.0.0.1:5000 |
 
 > Note: the .lock file is implemented for health-checking, but cannot be disabled yet. You must create this file in /tmp/.

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,8 @@ type WatchdogConfig struct {
 	ContentType      string
 	InjectCGIHeaders bool
 	OperationalMode  int
+	SuppressLock     bool
+	UpstreamURL      string
 }
 
 // Process returns a string for the process and a slice for the arguments from the FunctionProcess.
@@ -36,13 +38,21 @@ func New(env []string) (WatchdogConfig, error) {
 
 	envMap := mapEnv(env)
 
-	var functionProcess string
+	var (
+		functionProcess string
+		upstreamURL     string
+	)
+
 	if val, exists := envMap["fprocess"]; exists {
 		functionProcess = val
 	}
 
 	if val, exists := envMap["function_process"]; exists {
 		functionProcess = val
+	}
+
+	if val, exists := envMap["upstream_url"]; exists {
+		upstreamURL = val
 	}
 
 	contentType := "application/octet-stream"
@@ -59,6 +69,8 @@ func New(env []string) (WatchdogConfig, error) {
 		ExecTimeout:      getDuration(envMap, "exec_timeout", time.Second*10),
 		OperationalMode:  ModeStreaming,
 		ContentType:      contentType,
+		SuppressLock:     getBool(envMap, "suppress_lock"),
+		UpstreamURL:      upstreamURL,
 	}
 
 	if val := envMap["mode"]; len(val) > 0 {
@@ -102,4 +114,12 @@ func getInt(env map[string]string, key string, defaultValue int) int {
 	}
 
 	return result
+}
+
+func getBool(env map[string]string, key string) bool {
+	if env[key] == "true" {
+		return true
+	}
+
+	return false
 }

--- a/executor/http_runner.go
+++ b/executor/http_runner.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"os/exec"
 	"sync"
 	"time"
@@ -82,13 +81,6 @@ func (f *HTTPFunctionRunner) Start() error {
 	}()
 
 	f.Client = makeProxyClient(f.ExecTimeout)
-
-	urlValue, upstreamURLErr := url.Parse(os.Getenv("upstream_url"))
-	if upstreamURLErr != nil {
-		log.Fatal(upstreamURLErr)
-	}
-
-	f.UpstreamURL = urlValue
 
 	return cmd.Start()
 }


### PR DESCRIPTION
- As outlined in https://github.com/openfaas/faas/pull/873 and
in released 0.9.4 of the classic watchdog. This commit
dual-maintains the required changes to allow Kubernetes to remove
traffic in a graceful way meaning we will not see connection
refused errors and in-flight HTTP requests still get a chance to
finish.

Closes #15 

Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>