### PR TITLE
Fixes bug in pipeToProcess

### DIFF
--- a/executor/serializing_fork_runner_test.go
+++ b/executor/serializing_fork_runner_test.go
@@ -1,0 +1,129 @@
+package executor
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+)
+
+type mockWriter struct {
+	Error error
+}
+
+func (m mockWriter) Write(p []byte) (int, error) {
+	return len(p), m.Error
+}
+
+func (m mockWriter) Close() error {
+	return nil
+}
+
+type mockReader struct {
+	BytesRead []byte
+	Error     error
+}
+
+func (m mockReader) Read(p []byte) (int, error) {
+	copy(p, m.BytesRead)
+	return len(m.BytesRead), m.Error
+}
+
+func Test_PipeToProcess_ReturnsBothErrors(t *testing.T) {
+	expectedMockWriteError := errors.New("mockWriteError")
+	expectedMockReadError := errors.New("mockReadError")
+	expectedErr := errors.New("mockWriteError and mockReadError")
+
+	mockWrite := mockWriter{
+		Error: expectedMockWriteError,
+	}
+	mockRead := mockReader{
+		BytesRead: []byte(""),
+		Error:     expectedMockReadError,
+	}
+
+	data := []byte("data")
+	_, err := pipeToProcess(mockWrite, mockRead, &data)
+
+	if err == nil {
+		t.Fatalf("Expected non-nil error")
+	}
+
+	if err.Error() != expectedErr.Error() {
+		t.Errorf("Expected error to be: %v, got: %v", expectedErr, err)
+	}
+}
+
+func Test_PipeToProcess_ReturnsWriteError(t *testing.T) {
+	expectedMockWriteError := errors.New("mockWriteError")
+
+	mockWrite := mockWriter{
+		Error: expectedMockWriteError,
+	}
+	mockRead := mockReader{
+		BytesRead: []byte(""),
+		Error:     io.EOF,
+	}
+
+	data := []byte("data")
+	_, err := pipeToProcess(mockWrite, mockRead, &data)
+
+	if err == nil {
+		t.Fatalf("Expected non-nil error")
+	}
+
+	if err.Error() != expectedMockWriteError.Error() {
+		t.Errorf("Expected error to be: %v, got: %v", expectedMockWriteError, err)
+	}
+}
+
+func Test_PipeToProcess_ReturnsReadError(t *testing.T) {
+	expectedMockReadError := errors.New("mockReadError")
+
+	mockWrite := mockWriter{
+		Error: nil,
+	}
+	mockRead := mockReader{
+		BytesRead: []byte(""),
+		Error:     expectedMockReadError,
+	}
+
+	data := []byte("data")
+	_, err := pipeToProcess(mockWrite, mockRead, &data)
+
+	if err == nil {
+		t.Fatalf("Expected non-nil error")
+	}
+
+	if err.Error() != expectedMockReadError.Error() {
+		t.Errorf("Expected error to be: %v, got: %v", expectedMockReadError, err)
+	}
+}
+
+func Test_PipeToProcess_FunctionResult(t *testing.T) {
+	expectedFunctionResult := []byte("function result")
+
+	mockWrite := mockWriter{
+		Error: nil,
+	}
+	mockRead := mockReader{
+		BytesRead: expectedFunctionResult,
+		Error:     io.EOF,
+	}
+
+	data := []byte("data")
+	functionResult, err := pipeToProcess(mockWrite, mockRead, &data)
+
+	if err != nil {
+		t.Fatalf("Expected nil error")
+	}
+
+	if functionResult == nil {
+		t.Fatalf("functionResult is nil")
+	}
+
+	if !bytes.Equal(*functionResult, expectedFunctionResult) {
+		t.Errorf("functionResult is incorrect - got: %s expected: %s", string(*functionResult), string(expectedFunctionResult))
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Thomas Fan <thomasjpfan@gmail.com>

Fixes bug in `pipeToProcess` when recording errors. 

## Description
Since there are only two go routines, a slice of length 2 is used to store errors. After `wg.Wait()` the errors are combined and returned.

## Motivation and Context
In the previous implementation, when both the read and write go routines has an error, there were no guarantees that the `errors` slice gets populated with two errors. The go routine processing the `errChannel` may not have had the opportunity to process the second error when `wg.Wait` unblocks.

## How Has This Been Tested?
Unit tests were added to test the different error cases. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
