### PR TITLE
Add http_buffer to "http" mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,14 +140,16 @@ Environmental variables:
 
 | Option                 | Implemented | Usage             |
 |------------------------|--------------|-------------------------------|
-| `function_process`     | Yes          | The process to invoke for each function call function process (alias - fprocess). This must be a UNIX binary and accept input via STDIN and output via STDOUT.  |
+| `function_process`     | Yes          | Process to execute a server in `http` mode or to be executed for each request in the other modes. For non `http` mode the process must accept input via STDIN and print output via STDOUT. Alias: `fprocess` |
 | `read_timeout`         | Yes          | HTTP timeout for reading the payload from the client caller (in seconds) |
 | `write_timeout`        | Yes          | HTTP timeout for writing a response body from your function (in seconds)  |
 | `exec_timeout`         | Yes          | Exec timeout for process exec'd for each incoming request (in seconds). Disabled if set to 0. |
-| `port`                 | Yes          | Specify an alternative TCP port for testing |
-| `write_debug`          | No           | Write all output, error messages, and additional information to the logs. Default is false. |
+| `port`                 | Yes          | Specify an alternative TCP port for testing. Default: `8080` |
+| `write_debug`          | No           | Write all output, error messages, and additional information to the logs. Default is `false`. |
 | `content_type`         | Yes          | Force a specific Content-Type response for all responses - only in forking/serializing modes. |
-| `suppress_lock`        | Yes           | The watchdog will attempt to write a lockfile to /tmp/ for swarm healthchecks - set this to true to disable behaviour. |
-| `upstream_url`         | Yes          | `http` mode only - where to forward requests i.e. 127.0.0.1:5000 |
+| `suppress_lock`        | Yes           | When set to `false` the watchdog will attempt to write a lockfile to /tmp/ for healthchecks. Default `false` |
+| `upstream_url`         | Yes          | `http` mode only - where to forward requests i.e. `127.0.0.1:5000` |
+| `buffer_http`     | Yes               | `http` mode only - buffers request body to memory before fowarding. Use if your upstream HTTP server does not accept `Transfer-Encoding: chunked` Default: `false` |
+
 
 > Note: the .lock file is implemented for health-checking, but cannot be disabled yet. You must create this file in /tmp/.

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,11 @@ type WatchdogConfig struct {
 	OperationalMode  int
 	SuppressLock     bool
 	UpstreamURL      string
+
+	// BufferHTTPBody buffers the HTTP body in memory
+	// to prevent transfer type of chunked encoding
+	// which some servers do not support.
+	BufferHTTPBody bool
 }
 
 // Process returns a string for the process and a slice for the arguments from the FunctionProcess.
@@ -71,6 +76,7 @@ func New(env []string) (WatchdogConfig, error) {
 		ContentType:      contentType,
 		SuppressLock:     getBool(envMap, "suppress_lock"),
 		UpstreamURL:      upstreamURL,
+		BufferHTTPBody:   getBool(envMap, "buffer_http"),
 	}
 
 	if val := envMap["mode"]; len(val) > 0 {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,6 +22,33 @@ func Test_OperationalMode_Default(t *testing.T) {
 		t.Errorf("Want %s. got: %s", WatchdogMode(ModeStreaming), WatchdogMode(defaults.OperationalMode))
 	}
 }
+func Test_BufferHttpModeDefaultsToFalse(t *testing.T) {
+	env := []string{}
+
+	actual, err := New(env)
+	if err != nil {
+		t.Errorf("Expected no errors")
+	}
+	want := false
+	if actual.BufferHTTPBody != want {
+		t.Errorf("Want %v. got: %v", want, actual.BufferHTTPBody)
+	}
+}
+
+func Test_BufferHttpMode_CanBeSetToTrue(t *testing.T) {
+	env := []string{
+		"buffer_http=true",
+	}
+
+	actual, err := New(env)
+	if err != nil {
+		t.Errorf("Expected no errors")
+	}
+	want := true
+	if actual.BufferHTTPBody != want {
+		t.Errorf("Want %v. got: %v", want, actual.BufferHTTPBody)
+	}
+}
 
 func Test_OperationalMode_AfterBurn(t *testing.T) {
 	env := []string{
@@ -36,7 +63,6 @@ func Test_OperationalMode_AfterBurn(t *testing.T) {
 	if actual.OperationalMode != ModeAfterBurn {
 		t.Errorf("Want %s. got: %s", WatchdogMode(ModeAfterBurn), WatchdogMode(actual.OperationalMode))
 	}
-
 }
 
 func Test_ContentType_Default(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -278,9 +278,10 @@ func getEnvironment(r *http.Request) []string {
 func makeHTTPRequestHandler(watchdogConfig config.WatchdogConfig) func(http.ResponseWriter, *http.Request) {
 	commandName, arguments := watchdogConfig.Process()
 	functionInvoker := executor.HTTPFunctionRunner{
-		ExecTimeout: watchdogConfig.ExecTimeout,
-		Process:     commandName,
-		ProcessArgs: arguments,
+		ExecTimeout:    watchdogConfig.ExecTimeout,
+		Process:        commandName,
+		ProcessArgs:    arguments,
+		BufferHTTPBody: watchdogConfig.BufferHTTPBody,
 	}
 
 	if len(watchdogConfig.UpstreamURL) == 0 {


### PR DESCRIPTION
Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add http_buffer to "http" mode

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md)) closes #39 

Allows servers such as Swoole which do not implement the whole
HTTP spec to be used with of-watchdog. Apply this setting when
Transfer-Encoding: chunked is not compatible with your http
server in http mode.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with netcat "nc" outside of a Docker container to see
the output either sent with a content-length when turned on
or without one when in chunked mode.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
