### PR TITLE
Provide X-Duration-Seconds header in Serializing mode

### DIFF
--- a/executor/serializing_fork_runner.go
+++ b/executor/serializing_fork_runner.go
@@ -21,6 +21,7 @@ func (f *SerializingForkFunctionRunner) Run(req FunctionRequest, w http.Response
 	start := time.Now()
 	functionBytes, err := serializeFunction(req, f)
 	if err != nil {
+		w.Header().Set("X-Duration-Seconds", fmt.Sprintf("%f", time.Since(start).Seconds()))
 		w.WriteHeader(500)
 		w.Write([]byte(err.Error()))
 		return err

--- a/executor/serializing_fork_runner.go
+++ b/executor/serializing_fork_runner.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -17,13 +18,14 @@ type SerializingForkFunctionRunner struct {
 
 // Run run a fork for each invocation
 func (f *SerializingForkFunctionRunner) Run(req FunctionRequest, w http.ResponseWriter) error {
+	start := time.Now()
 	functionBytes, err := serializeFunction(req, f)
 	if err != nil {
 		w.WriteHeader(500)
 		w.Write([]byte(err.Error()))
 		return err
 	}
-
+	w.Header().Set("X-Duration-Seconds", fmt.Sprintf("%f", time.Since(start).Seconds()))
 	w.WriteHeader(200)
 
 	if functionBytes != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added the X-Duration-Seconds Header in Serializing mode as described in #38.
## Description
<!--- Describe your changes in detail -->
Added the header in Serializing mode in all cases (success, error)
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There was an issue (#38) raised about the missing header, which was needed for consistency across classic and of-watchdog.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I've ran of-watchdog locally in serializing mode in cases where the request would return success or error, and checked that the X-Duration-Seconds header is set correctly when sending a request to of-watchdog in both cases.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
