### PR TITLE
Build to create images with binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,34 @@ addons:
 before_install: 
 script:
 - sh build.sh
+after_success:
+  - if [ -z $DOCKER_NS ] ; then
+      export DOCKER_NS=functions;
+      fi
+  - if [ ! -z "$TRAVIS_TAG" ] ; then
+      export DOCKER_CLI_EXPERIMENTAL=enabled
+
+      docker tag $DOCKER_NS/of-watchdog:latest-dev-darwin $DOCKER_NS/of-watchdog:$TRAVIS_TAG-darwin;
+      docker tag $DOCKER_NS/of-watchdog:latest-dev-armhf $DOCKER_NS/of-watchdog:$TRAVIS_TAG-armhf;
+      docker tag $DOCKER_NS/of-watchdog:latest-dev-arm64 $DOCKER_NS/of-watchdog:$TRAVIS_TAG-arm64;
+      docker tag $DOCKER_NS/of-watchdog:latest-dev-windows $DOCKER_NS/of-watchdog:$TRAVIS_TAG-windows;
+      docker tag $DOCKER_NS/of-watchdog:latest-dev-x86_64 $DOCKER_NS/of-watchdog:$TRAVIS_TAG-x86_64;
+      echo $DOCKER_PASSWORD | docker login -u=$DOCKER_USERNAME --password-stdin;
+      docker push $DOCKER_NS/of-watchdog:$TRAVIS_TAG-darwin;
+      docker push $DOCKER_NS/of-watchdog:$TRAVIS_TAG-armhf;
+      docker push $DOCKER_NS/of-watchdog:$TRAVIS_TAG-arm64;
+      docker push $DOCKER_NS/of-watchdog:$TRAVIS_TAG-windows; 
+      docker push $DOCKER_NS/of-watchdog:$TRAVIS_TAG-x86_64;
+
+      ./make_manifest.sh
+      docker push $DOCKER_NS/of-watchdog:$TRAVIS_TAG
+
+      echo $QUAY_PASSWORD | docker login -u=$QUAY_USERNAME --password-stdin quay.io;
+      docker push quay.io/$DOCKER_NS/of-watchdog:$TRAVIS_TAG-armhf;
+      docker push quay.io/$DOCKER_NS/of-watchdog:$TRAVIS_TAG-arm64;
+      docker push quay.io/$DOCKER_NS/of-watchdog:$TRAVIS_TAG-windows; 
+      docker push quay.io/$DOCKER_NS/of-watchdog:$TRAVIS_TAG-x86_64;
+      fi
 before_deploy:
   - ./ci/hashgen.sh
 deploy:
@@ -28,4 +56,4 @@ deploy:
   - "./of-watchdog.exe.sha256"
   skip_cleanup: true
   on:
-    tags: true
+    tags: true  

--- a/Dockerfile.packager
+++ b/Dockerfile.packager
@@ -1,0 +1,6 @@
+FROM functions/of-watchdog:build as build
+FROM scratch
+
+ARG PLATFORM
+
+COPY --from=build /go/src/github.com/openfaas-incubator/of-watchdog/of-watchdog$PLATFORM ./fwatchdog

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,4 @@
-#!/bin/sh
-
-export arch=$(uname -m)
-
-if [ ! "$arch" = "x86_64" ] ; then
-    echo "Build not supported on $arch, use cross-build."
-    exit 1
-fi
+#!/bin/bash
 
 if [ ! "$http_proxy" = "" ]
 then
@@ -13,6 +6,12 @@ then
 else
     docker build -t functions/of-watchdog:build .
 fi
+
+docker build --no-cache --build-arg PLATFORM="-darwin" -t openfaas/of-watchdog:latest-dev-darwin . -f Dockerfile.packager
+docker build --no-cache --build-arg PLATFORM="-armhf" -t openfaas/of-watchdog:latest-dev-armhf . -f Dockerfile.packager
+docker build --no-cache --build-arg PLATFORM="-arm64" -t openfaas/of-watchdog:latest-dev-arm64 . -f Dockerfile.packager
+docker build --no-cache --build-arg PLATFORM=".exe" -t openfaas/of-watchdog:latest-dev-windows . -f Dockerfile.packager
+docker build --no-cache --build-arg PLATFORM="" -t openfaas/of-watchdog:latest-dev-x86_64 . -f Dockerfile.packager
 
 docker create --name buildoutput functions/of-watchdog:build echo
 

--- a/make_manifest.sh
+++ b/make_manifest.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+export USR=$DOCKER_NS
+export TAG=$TRAVIS_TAG
+
+docker manifest create $USR/of-watchdog:$TAG \
+  $USR/of-watchdog:$TAG-darwin \
+  $USR/of-watchdog:$TAG-x86_64 \
+  $USR/of-watchdog:$TAG-armhf \
+  $USR/of-watchdog:$TAG-arm64 \
+  $USR/of-watchdog:$TAG-windows
+
+docker manifest annotate $USR/of-watchdog:$TAG --arch arm $USR/of-watchdog:$TAG-darwin
+docker manifest annotate $USR/of-watchdog:$TAG --arch arm $USR/of-watchdog:$TAG-armhf
+docker manifest annotate $USR/of-watchdog:$TAG --arch arm64 $USR/of-watchdog:$TAG-arm64
+docker manifest annotate $USR/of-watchdog:$TAG --os windows $USR/of-watchdog:$TAG-windows
+
+docker manifest push $USR/of-watchdog:$TAG


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update the build to create images of the binaries for each
of the supported platforms: darwin, armhf, arm64, windows,
and x86_64 (linux)

Also updated the travis file in order to push these images
up to docker hub and create a manifest file for easy
multi-arch image pulls

Signed-off-by: Burton Rheutan <rheutan7@gmail.com>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Resolves #59 

Heavily influenced by the awesome work by @rgee0 on https://github.com/openfaas/faas/pull/1165

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running the `build.sh` script locally and verifying each of the created images exists.
Running  the `make_manifest.sh` script locally and seeing the expected output

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
