### PR TITLE
Added information what http server listen on

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,6 +107,8 @@ func listenUntilShutdown(shutdownTimeout time.Duration, s *http.Server, suppress
 
 	// Run the HTTP server in a separate go-routine.
 	go func() {
+		log.Printf("HTTP server. Listen: %v", s.Addr)
+
 		if err := s.ListenAndServe(); err != http.ErrServerClosed {
 			log.Printf("Error ListenAndServe: %v", err)
 			close(idleConnsClosed)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Give information where the HTTP server listen on

## Motivation and Context
It is not information where http port is listen, like the metrics server.

- [x] I have raised an issue to propose this change ([required]

https://github.com/openfaas-incubator/of-watchdog/issues/67


## How Has This Been Tested?
Just execute it and see that output is correct

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
