### PR TITLE
Use bufio.Scanner for reading stderr and stdout

### DIFF
--- a/executor/afterburn_runner.go
+++ b/executor/afterburn_runner.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"os/exec"
 	"sync"
 )
@@ -42,7 +43,7 @@ func (f *AfterBurnFunctionRunner) Start() error {
 	errPipe, _ := cmd.StderrPipe()
 
 	// Prints stderr to console and is picked up by container logging driver.
-	bindLoggingPipe("stderr", errPipe)
+	bindLoggingPipe("stderr", errPipe, os.Stderr)
 
 	return cmd.Start()
 }

--- a/executor/afterburn_runner.go
+++ b/executor/afterburn_runner.go
@@ -42,20 +42,7 @@ func (f *AfterBurnFunctionRunner) Start() error {
 	errPipe, _ := cmd.StderrPipe()
 
 	// Prints stderr to console and is picked up by container logging driver.
-	go func() {
-		log.Println("Started logging stderr from function.")
-		for {
-			errBuff := make([]byte, 256)
-
-			_, err := errPipe.Read(errBuff)
-			if err != nil {
-				log.Printf("Error reading stderr: %s", err)
-
-			} else {
-				log.Printf("stderr: %s", errBuff)
-			}
-		}
-	}()
+	bindLoggingPipe("stderr", errPipe)
 
 	return cmd.Start()
 }

--- a/executor/http_runner.go
+++ b/executor/http_runner.go
@@ -52,9 +52,9 @@ func (f *HTTPFunctionRunner) Start() error {
 
 	errPipe, _ := cmd.StderrPipe()
 
-	// Prints stderr to console and is picked up by container logging driver.
-	bindLoggingPipe("stderr", errPipe)
-	bindLoggingPipe("stdout", f.StdoutPipe)
+	// Logs lines from stderr and stdout to the stderr and stdout of this process
+	bindLoggingPipe("stderr", errPipe, os.Stderr)
+	bindLoggingPipe("stdout", f.StdoutPipe, os.Stdout)
 
 	f.Client = makeProxyClient(f.ExecTimeout)
 

--- a/executor/logging.go
+++ b/executor/logging.go
@@ -7,14 +7,15 @@ import (
 )
 
 // bindLoggingPipe spawns a goroutine for passing through logging of the given output pipe.
-func bindLoggingPipe(name string, output io.Reader) {
+func bindLoggingPipe(name string, pipe io.Reader, output io.Writer) {
 	log.Printf("Started logging %s from function.", name)
 
-	scanner := bufio.NewScanner(output)
+	scanner := bufio.NewScanner(pipe)
+	logger := log.New(output, log.Prefix(), log.Flags())
 
 	go func() {
 		for scanner.Scan() {
-			log.Printf("%s: %s", name, scanner.Text())
+			logger.Println(scanner.Text())
 		}
 		if err := scanner.Err(); err != nil {
 			log.Printf("Error scanning %s: %s", name, err.Error())

--- a/executor/logging.go
+++ b/executor/logging.go
@@ -1,0 +1,23 @@
+package executor
+
+import (
+	"bufio"
+	"io"
+	"log"
+)
+
+// bindLoggingPipe spawns a goroutine for passing through logging of the given output pipe.
+func bindLoggingPipe(name string, output io.Reader) {
+	log.Printf("Started logging %s from function.", name)
+
+	scanner := bufio.NewScanner(output)
+
+	go func() {
+		for scanner.Scan() {
+			log.Printf("%s: %s", name, scanner.Text())
+		}
+		if err := scanner.Err(); err != nil {
+			log.Printf("Error scanning %s: %s", name, err.Error())
+		}
+	}()
+}

--- a/executor/streaming_runner.go
+++ b/executor/streaming_runner.go
@@ -65,24 +65,7 @@ func (f *ForkFunctionRunner) Run(req FunctionRequest) error {
 	errPipe, _ := cmd.StderrPipe()
 
 	// Prints stderr to console and is picked up by container logging driver.
-	go func() {
-		log.Println("Started logging stderr from function.")
-		for {
-			errBuff := make([]byte, 256)
-
-			n, err := errPipe.Read(errBuff)
-			if err != nil {
-				if err != io.EOF {
-					log.Printf("Error reading stderr: %s", err)
-				}
-				break
-			} else {
-				if n > 0 {
-					log.Printf("stderr: %s", errBuff)
-				}
-			}
-		}
-	}()
+	bindLoggingPipe("stderr", errPipe)
 
 	startErr := cmd.Start()
 

--- a/executor/streaming_runner.go
+++ b/executor/streaming_runner.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"os/exec"
 	"time"
 )
@@ -65,7 +66,7 @@ func (f *ForkFunctionRunner) Run(req FunctionRequest) error {
 	errPipe, _ := cmd.StderrPipe()
 
 	// Prints stderr to console and is picked up by container logging driver.
-	bindLoggingPipe("stderr", errPipe)
+	bindLoggingPipe("stderr", errPipe, os.Stderr)
 
 	startErr := cmd.Start()
 


### PR DESCRIPTION
## Description
Replaced the 256 byte slurping goroutine with a bufio.Scanner powered one.
Reduced some code duplication by adding a go routine spawner for passing through logging
Made the http executor use cmd.Wait for closing the forked process instead of catching EOFs on stderr/out.
Removed a vestigial field `Stderr` on the `HttpRunner`

## Motivation and Context
This was done to address the gotchas and generally poor user experience I've been having with using stderr and stdout for logging in my wrapped function process.  The issues have been listed in #75.  There is another proposed solution in #77 which seeks to address the problem by increasing the buffer size (and also allowing writing to stdout).

Where this one is superior is that it allows common log line prefixing to exist for log lines generated by the watchdog itself and those piped from the wrapped function process.  It can accomplish this because the scanner splitting on new lines ensures that line breaks from the wrapped function are preserved (up to a single line size of 64Kb).  If arbitrary splitting is done based on a buffer size as we currently do with 256 bytes, we're likely to get split lines that did not exist in the original output.  If we just increase that buffer size and pass-through from the wrapped process like we do in #77  we now potentially include line breaks and formatting from the wrapped process that result in a non-uniform output in the watchdogs logs.

## How Has This Been Tested?
I tested this using a [contrived http mode go function named `chatty-fn`](https://github.com/cconger/chatty-fn) that just logs requests that it receives and a bunch of other extra information.  I built the `chatty-fn` docker container and included different watchdogs to wrap it.  I then boot the docker container directly, and issue network requests directly to it.

```bash
# Within chatty-fn
docker build -t chatty-fn:latest .
docker run -p 8080:8080 chatty-fn:latest > stdout.log 2> stderr.log
curl -X POST localhost:8080 -H 'Content-Type: application/json' --data '{"hello": "world"}'
```

When built using the 0.5.3 of-watchdog it yields the following outputs:
**stdout.log**
```
Forking - /home/app/function []
```

**stderr.log**
```
2019/08/26 23:11:21 Started logging stderr from function.
2019/08/26 23:11:21 Started logging stdout from function.
2019/08/26 23:11:21 OperationalMode: http
2019/08/26 23:11:21 Writing lock-file to: /tmp/.lock
2019/08/26 23:11:21 Metrics server. Port: 8081
2019/08/26 23:11:21 stderr: Starting application server

2019/08/26 23:11:21 stdout: This is a warning to stdout

2019/08/26 23:11:28 stderr: Received request

2019/08/26 23:11:28 stdout: This is me writing to stdout on request: {"Method":"POST","URL":"/","Proto":"HTTP/1.1","Host":"localhost:8080","RemoteAddr":"127.0.0.1:51310","ContentLength":-1,"Body":"{\"hello\": \"world\"}","Headers":{"Accept":["*/*"],"Accept-Encoding":["gzip"],"Content
2019/08/26 23:11:28 stderr: Request: {"Method":"POST","URL":"/","Proto":"HTTP/1.1","Host":"localhost:8080","RemoteAddr":"127.0.0.1:51310","ContentLength":-1,"Body":"{\"hello\": \"world\"}","Headers":{"Accept":["*/*"],"Accept-Encoding":["gzip"],"Content-Type":["application/json"],"Use
2019/08/26 23:11:28 stdout: -Type":["application/json"],"User-Agent":["curl/7.54.0"]},"ReceivedAt":"2019-08-26T23:11:28.2348614Z"}
I liked what I got... so I'm gonna 200 OK

2019/08/26 23:11:28 stderr: r-Agent":["curl/7.54.0"]},"ReceivedAt":"2019-08-26T23:11:28.2348614Z"}

2019/08/26 23:11:28 POST / - 200 OK - ContentLength: 2
```

When building with this branch the resulting log lines look like:
**stdout.log**
```
Forking - /home/app/function []
2019/08/26 23:06:20 This is a warning to stdout
2019/08/26 23:06:25 This is me writing to stdout on request: {"Method":"POST","URL":"/","Proto":"HTTP/1.1","Host":"localhost:8080","RemoteAddr":"127.0.0.1:49484","ContentLength":-1,"Body":"{\"hello\": \"world\"}","Headers":{"Accept":["*/*"],"Accept-Encoding":["gzip"],"Content-Type":["application/json"],"User-Agent":["curl/7.54.0"]},"ReceivedAt":"2019-08-26T23:06:25.2655911Z"}
2019/08/26 23:06:25 I liked what I got... so I'm gonna 200 OK
```

**stderr.log**
```
2019/08/26 23:06:20 Started logging stderr from function.
2019/08/26 23:06:20 Started logging stdout from function.
2019/08/26 23:06:20 OperationalMode: http
2019/08/26 23:06:20 Timeouts: read: 10s, write: 10s hard: 10s.
2019/08/26 23:06:20 Listening on port: 8080
2019/08/26 23:06:20 Writing lock-file to: /tmp/.lock
2019/08/26 23:06:20 Metrics listening on port: 8081
2019/08/26 23:06:20 Starting application server
2019/08/26 23:06:25 Received request
2019/08/26 23:06:25 Request: {"Method":"POST","URL":"/","Proto":"HTTP/1.1","Host":"localhost:8080","RemoteAddr":"127.0.0.1:49484","ContentLength":-1,"Body":"{\"hello\": \"world\"}","Headers":{"Accept":["*/*"],"Accept-Encoding":["gzip"],"Content-Type":["application/json"],"User-Agent":["curl/7.54.0"]},"ReceivedAt":"2019-08-26T23:06:25.2655911Z"}
2019/08/26 23:06:25 POST / - 200 OK - ContentLength: 2
```

### Testing on Kubernetes
Additionally I've published two docker images for `chatty-fn` on Docker Hub
`cconger/chatty-fn:0.5.3` and `cconger/chatty-fn:latest`.

I deployed them onto Kubernetes based deployment of Openfaas.

I tested reading the logs via kubectl.
**Original**
```
> kubectl kubectl --namespace openfaas-fn logs logger-original-84b6fdcbf9-vb7l5
Forking - /home/app/function []
2019/08/27 00:34:58 Started logging stderr from function.
2019/08/27 00:34:58 OperationalMode: http
2019/08/27 00:34:58 Started logging stdout from function.
2019/08/27 00:34:58 Writing lock-file to: /tmp/.lock
2019/08/27 00:34:58 Metrics server. Port: 8081
2019/08/27 00:34:58 stdout: This is a warning to stdout
                                                                                                                                                                                                                                    
2019/08/27 00:34:58 stderr: Starting application server
                                                                                                                                                                                                                                    
2019/08/27 00:35:06 stdout: This is me writing to stdout on request: {"Method":"POST","URL":"/","Proto":"HTTP/1.1","Host":"logger-original.openfaas-fn.svc.cluster.local:8080","RemoteAddr":"127.0.0.1:55764","ContentLength":-1,"Body":"{'hello': 'world'}","Headers":{"Accept":["applicati
2019/08/27 00:35:06 stdout: on/json, text/plain, */*"],"Accept-Encoding":["gzip, deflate, br"],"Accept-Language":["en-US,en;q=0.9"],"Content-Type":["application/json"],"Origin":["http://localhost:31112"],"Referer":["http://localhost:31112/ui/"],"Sec-Fetch-Mode":["cors"],"Sec-Fetch-Si
2019/08/27 00:35:06 stdout: te":["same-origin"],"User-Agent":["Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36"],"X-Call-Id":["857ca38b-941f-46a7-a034-93437f81cbf8"],"X-Forwarded-For":["192.168.65.3:59938"],"X-
2019/08/27 00:35:06 stdout: Forwarded-Host":["localhost:31112"],"X-Start-Time":["1566866106940407400"]},"ReceivedAt":"2019-08-27T00:35:06.9480898Z"}
I liked what I got... so I'm gonna 200 OK
                                                                                             
2019/08/27 00:35:06 POST / - 200 OK - ContentLength: 2
2019/08/27 00:35:06 stderr: Received request
Request: {"Method":"POST","URL":"/","Proto":"HTTP/1.1","Host":"logger-original.openfaas-fn.svc.cluster.local:8080","RemoteAddr":"127.0.0.1:55764","ContentLength":-1,"Body":"{'hello': 'world'}","Headers":{"Accept":["application/json, text/p
2019/08/27 00:35:06 stderr: lain, */*"],"Accept-Encoding":["gzip, deflate, br"],"Accept-Language":["en-US,en;q=0.9"],"Content-Type":["application/json"],"Origin":["http://localhost:31112"],"Referer":["http://localhost:31112/ui/"],"Sec-Fetch-Mode":["cors"],"Sec-Fetch-Site":["same-orig
2019/08/27 00:35:06 stderr: in"],"User-Agent":["Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36"],"X-Call-Id":["857ca38b-941f-46a7-a034-93437f81cbf8"],"X-Forwarded-For":["192.168.65.3:59938"],"X-Forwarded-Host"
2019/08/27 00:35:06 stderr: :["localhost:31112"],"X-Start-Time":["1566866106940407400"]},"ReceivedAt":"2019-08-27T00:35:06.9480898Z"}
                                                                                                                                                      
```

**New**
```
> kubectl --namespace openfaas-fn logs logger-65985b8697-mg64m
Forking - /home/app/function []
2019/08/27 00:30:59 Started logging stderr from function.
2019/08/27 00:30:59 Started logging stdout from function.
2019/08/27 00:30:59 OperationalMode: http
2019/08/27 00:30:59 Timeouts: read: 10s, write: 10s hard: 10s.
2019/08/27 00:30:59 Listening on port: 8080
2019/08/27 00:30:59 Writing lock-file to: /tmp/.lock
2019/08/27 00:30:59 Metrics listening on port: 8081
2019/08/27 00:30:59 Starting application server
2019/08/27 00:30:59 This is a warning to stdout
2019/08/27 00:31:12 Received request
2019/08/27 00:31:12 This is me writing to stdout on request: {"Method":"POST","URL":"/","Proto":"HTTP/1.1","Host":"logger.openfaas-fn.svc.cluster.local:8080","RemoteAddr":"127.0.0.1:53308","ContentLength":-1,"Body":"{\"hello\": \"world\"}","Headers":{"Accept":["application/json, text/plain, */*"],"Accept-Encoding":["gzip, deflate, br"],"Accept-Language":["en-US,en;q=0.9"],"Content-Type":["application/json"],"Origin":["http://localhost:31112"],"Referer":["http://localhost:31112/ui/"],"Sec-Fetch-Mode":["cors"],"Sec-Fetch-Site":["same-origin"],"User-Agent":["Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36"],"X-Call-Id":["4951f4e6-9da7-4ecf-aa7b-660ba30f868b"],"X-Forwarded-For":["192.168.65.3:34074"],"X-Forwarded-Host":["localhost:31112"],"X-Start-Time":["1566865872612459700"]},"ReceivedAt":"2019-08-27T00:31:12.6205404Z"}
2019/08/27 00:31:12 I liked what I got... so I'm gonna 200 OK
2019/08/27 00:31:12 Request: {"Method":"POST","URL":"/","Proto":"HTTP/1.1","Host":"logger.openfaas-fn.svc.cluster.local:8080","RemoteAddr":"127.0.0.1:53308","ContentLength":-1,"Body":"{\"hello\": \"world\"}","Headers":{"Accept":["application/json, text/plain, */*"],"Accept-Encoding":["gzip, deflate, br"],"Accept-Language":["en-US,en;q=0.9"],"Content-Type":["application/json"],"Origin":["http://localhost:31112"],"Referer":["http://localhost:31112/ui/"],"Sec-Fetch-Mode":["cors"],"Sec-Fetch-Site":["same-origin"],"User-Agent":["Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36"],"X-Call-Id":["4951f4e6-9da7-4ecf-aa7b-660ba30f868b"],"X-Forwarded-For":["192.168.65.3:34074"],"X-Forwarded-Host":["localhost:31112"],"X-Start-Time":["1566865872612459700"]},"ReceivedAt":"2019-08-27T00:31:12.6205404Z"}
2019/08/27 00:31:12 POST / - 200 OK - ContentLength: 2
```

And via faas-cli logs:

**Original**
```
> faas-cli logs logger-original
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
2019-08-27T00:45:11Z logger-original (logger-original-84b6fdcbf9-vb7l5) 2019/08/27 00:45:11 stderr: Received request
2019-08-27T00:45:11Z logger-original (logger-original-84b6fdcbf9-vb7l5)
2019-08-27T00:45:11Z logger-original (logger-original-84b6fdcbf9-vb7l5) 2019/08/27 00:45:11 stderr: Request: {"Method":"POST","URL":"/","Proto":"HTTP/1.1","Host":"logger-original.openfaas-fn.svc.cluster.local:8080","RemoteAddr":"127.0.0.1:34898","ContentLength":-1,"Body":"{\"hello\": \"world\"}","Headers":{"Accept":["application/json, text/plain, */*"],"
2019-08-27T00:45:11Z logger-original (logger-original-84b6fdcbf9-vb7l5) 2019/08/27 00:45:11 stderr: Accept-Encoding":["gzip, deflate, br"],"Accept-Language":["en-US,en;q=0.9"],"Content-Type":["application/json"],"Origin":["http://localhost:31112"],"Referer":["http://localhost:31112/ui/"],"Sec-Fetch-Mode":["cors"],"Sec-Fetch-Site":["same-origin"],"User-Ag
2019-08-27T00:45:11Z logger-original (logger-original-84b6fdcbf9-vb7l5) 2019/08/27 00:45:11 stderr: ent":["Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36"],"X-Call-Id":["319ceca3-35d8-47de-a15a-2f6cf9b58daa"],"X-Forwarded-For":["192.168.65.3:34074"],"X-Forwarded-Host":["localhost:
2019-08-27T00:45:11Z logger-original (logger-original-84b6fdcbf9-vb7l5) 2019/08/27 00:45:11 stderr: 31112"],"X-Start-Time":["1566866711001639600"]},"ReceivedAt":"2019-08-27T00:45:11.0082648Z"}
2019-08-27T00:45:11Z logger-original (logger-original-84b6fdcbf9-vb7l5)
2019-08-27T00:45:11Z logger-original (logger-original-84b6fdcbf9-vb7l5) 2019/08/27 00:45:11 POST / - 200 OK - ContentLength: 2
2019-08-27T00:45:11Z logger-original (logger-original-84b6fdcbf9-vb7l5) 2019/08/27 00:45:11 stdout: This is me writing to stdout on request: {"Method":"POST","URL":"/","Proto":"HTTP/1.1","Host":"logger-original.openfaas-fn.svc.cluster.local:8080","RemoteAddr":"127.0.0.1:34898","ContentLength":-1,"Body":"{\"hello\": \"world\"}","Headers":{"Accept":["appli
2019-08-27T00:45:11Z logger-original (logger-original-84b6fdcbf9-vb7l5) 2019/08/27 00:45:11 stdout: cation/json, text/plain, */*"],"Accept-Encoding":["gzip, deflate, br"],"Accept-Language":["en-US,en;q=0.9"],"Content-Type":["application/json"],"Origin":["http://localhost:31112"],"Referer":["http://localhost:31112/ui/"],"Sec-Fetch-Mode":["cors"],"Sec-Fetc
2019-08-27T00:45:11Z logger-original (logger-original-84b6fdcbf9-vb7l5) 2019/08/27 00:45:11 stdout: h-Site":["same-origin"],"User-Agent":["Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36"],"X-Call-Id":["319ceca3-35d8-47de-a15a-2f6cf9b58daa"],"X-Forwarded-For":["192.168.65.3:34074"]
2019-08-27T00:45:11Z logger-original (logger-original-84b6fdcbf9-vb7l5) 2019/08/27 00:45:11 stdout: ,"X-Forwarded-Host":["localhost:31112"],"X-Start-Time":["1566866711001639600"]},"ReceivedAt":"2019-08-27T00:45:11.0082648Z"}
2019-08-27T00:45:11Z logger-original (logger-original-84b6fdcbf9-vb7l5) I liked what I got... so I'm gonna 200 OK
2019-08-27T00:45:11Z logger-original (logger-original-84b6fdcbf9-vb7l5)

```

**New**
```
> faas-cli logs logger
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
2019-08-27T00:42:21Z logger (logger-65985b8697-mg64m) 2019/08/27 00:42:21 Received request
2019-08-27T00:42:21Z logger (logger-65985b8697-mg64m) 2019/08/27 00:42:21 This is me writing to stdout on request: {"Method":"POST","URL":"/","Proto":"HTTP/1.1","Host":"logger.openfaas-fn.svc.cluster.local:8080","RemoteAddr":"127.0.0.1:32812","ContentLength":-1,"Body":"{\"hello\": \"world\"}","Headers":{"Accept":["application/json, text/plain, */*"],"Accept-Encoding":["gzip, deflate, br"],"Accept-Language":["en-US,en;q=0.9"],"Content-Type":["application/json"],"Origin":["http://localhost:31112"],"Referer":["http://localhost:31112/ui/"],"Sec-Fetch-Mode":["cors"],"Sec-Fetch-Site":["same-origin"],"User-Agent":["Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36"],"X-Call-Id":["ae9ebe9d-1ff3-499a-b70f-578792e6e0b6"],"X-Forwarded-For":["192.168.65.3:59938"],"X-Forwarded-Host":["localhost:31112"],"X-Start-Time":["1566866541494492800"]},"ReceivedAt":"2019-08-27T00:42:21.500499Z"}
2019-08-27T00:42:21Z logger (logger-65985b8697-mg64m) 2019/08/27 00:42:21 I liked what I got... so I'm gonna 200 OK
2019-08-27T00:42:21Z logger (logger-65985b8697-mg64m) 2019/08/27 00:42:21 Request: {"Method":"POST","URL":"/","Proto":"HTTP/1.1","Host":"logger.openfaas-fn.svc.cluster.local:8080","RemoteAddr":"127.0.0.1:32812","ContentLength":-1,"Body":"{\"hello\": \"world\"}","Headers":{"Accept":["application/json, text/plain, */*"],"Accept-Encoding":["gzip, deflate, br"],"Accept-Language":["en-US,en;q=0.9"],"Content-Type":["application/json"],"Origin":["http://localhost:31112"],"Referer":["http://localhost:31112/ui/"],"Sec-Fetch-Mode":["cors"],"Sec-Fetch-Site":["same-origin"],"User-Agent":["Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36"],"X-Call-Id":["ae9ebe9d-1ff3-499a-b70f-578792e6e0b6"],"X-Forwarded-For":["192.168.65.3:59938"],"X-Forwarded-Host":["localhost:31112"],"X-Start-Time":["1566866541494492800"]},"ReceivedAt":"2019-08-27T00:42:21.500499Z"}
2019-08-27T00:42:21Z logger (logger-65985b8697-mg64m) 2019/08/27 00:42:21 POST / - 200 OK - ContentLength: 2
2019-08-27T00:44:30Z logger (logger-65985b8697-mg64m) 2019/08/27 00:44:30 Received request
2019-08-27T00:44:30Z logger (logger-65985b8697-mg64m) 2019/08/27 00:44:30 This is me writing to stdout on request: {"Method":"POST","URL":"/","Proto":"HTTP/1.1","Host":"logger.openfaas-fn.svc.cluster.local:8080","RemoteAddr":"127.0.0.1:34396","ContentLength":-1,"Body":"{\"hello\": \"world\"}","Headers":{"Accept":["application/json, text/plain, */*"],"Accept-Encoding":["gzip, deflate, br"],"Accept-Language":["en-US,en;q=0.9"],"Content-Type":["application/json"],"Origin":["http://localhost:31112"],"Referer":["http://localhost:31112/ui/"],"Sec-Fetch-Mode":["cors"],"Sec-Fetch-Site":["same-origin"],"User-Agent":["Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36"],"X-Call-Id":["62bc86ec-134e-4012-a456-da94f5485162"],"X-Forwarded-For":["192.168.65.3:59938"],"X-Forwarded-Host":["localhost:31112"],"X-Start-Time":["1566866670567143700"]},"ReceivedAt":"2019-08-27T00:44:30.572722Z"}
2019-08-27T00:44:30Z logger (logger-65985b8697-mg64m) 2019/08/27 00:44:30 I liked what I got... so I'm gonna 200 OK
2019-08-27T00:44:30Z logger (logger-65985b8697-mg64m) 2019/08/27 00:44:30 Request: {"Method":"POST","URL":"/","Proto":"HTTP/1.1","Host":"logger.openfaas-fn.svc.cluster.local:8080","RemoteAddr":"127.0.0.1:34396","ContentLength":-1,"Body":"{\"hello\": \"world\"}","Headers":{"Accept":["application/json, text/plain, */*"],"Accept-Encoding":["gzip, deflate, br"],"Accept-Language":["en-US,en;q=0.9"],"Content-Type":["application/json"],"Origin":["http://localhost:31112"],"Referer":["http://localhost:31112/ui/"],"Sec-Fetch-Mode":["cors"],"Sec-Fetch-Site":["same-origin"],"User-Agent":["Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36"],"X-Call-Id":["62bc86ec-134e-4012-a456-da94f5485162"],"X-Forwarded-For":["192.168.65.3:59938"],"X-Forwarded-Host":["localhost:31112"],"X-Start-Time":["1566866670567143700"]},"ReceivedAt":"2019-08-27T00:44:30.572722Z"}
2019-08-27T00:44:30Z logger (logger-65985b8697-mg64m) 2019/08/27 00:44:30 POST / - 200 OK - ContentLength: 2
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

This is a breaking change since it changes the default output location (things can actually appear in stdout now) and drastically changes the shape of output logs.

Documentation or release notes should likely be updated to alert consumers to this behavior change.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
