### PR TITLE
Implement a new `static` mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ See also: [Classic Watchdog](https://github.com/openfaas/faas/tree/master/watchd
 
 History/context: the original watchdog supported mode the Serializing fork mode only and Afterburn was available for testing via a pull request.
 
-When the of-watchdog is complete this version will support four modes as listed below. We may consolidate or remove some of these modes before going to 1.0 so please consider modes 2-4 experimental.
+When the of-watchdog is complete this version will support five modes as listed below. We may consolidate or remove some of these modes before going to 1.0 so please consider modes 2-4 experimental.
 
 ### 1. HTTP (mode=http)
 
@@ -143,6 +143,10 @@ Vastly accelerated processing speed but requires a client library for each langu
 
 * Exec timeout: not supported.
 
+### 5. Static (mode=static)
+
+This mode starts an HTTP file server for serving static content found at the directory specified by `static_path`.
+
 ## Configuration
 
 Environmental variables:
@@ -152,6 +156,7 @@ Environmental variables:
 | Option                 | Implemented | Usage             |
 |------------------------|--------------|-------------------------------|
 | `function_process`     | Yes          | Process to execute a server in `http` mode or to be executed for each request in the other modes. For non `http` mode the process must accept input via STDIN and print output via STDOUT. Alias: `fprocess` |
+| `static_path`          | Yes          | Absolute or relative path to the directory that will be served if `mode="static"` |
 | `read_timeout`         | Yes          | HTTP timeout for reading the payload from the client caller (in seconds) |
 | `write_timeout`        | Yes          | HTTP timeout for writing a response body from your function (in seconds)  |
 | `exec_timeout`         | Yes          | Exec timeout for process exec'd for each incoming request (in seconds). Disabled if set to 0. |

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ type WatchdogConfig struct {
 	OperationalMode  int
 	SuppressLock     bool
 	UpstreamURL      string
+	StaticPath       string
 
 	// BufferHTTPBody buffers the HTTP body in memory
 	// to prevent transfer type of chunked encoding
@@ -48,7 +49,7 @@ func (w WatchdogConfig) Process() (string, []string) {
 }
 
 // New create config based upon environmental variables.
-func New(env []string) (WatchdogConfig, error) {
+func New(env []string) WatchdogConfig {
 
 	envMap := mapEnv(env)
 
@@ -74,11 +75,17 @@ func New(env []string) (WatchdogConfig, error) {
 		contentType = val
 	}
 
+	staticPath := "/home/app/public"
+	if val, exists := envMap["static_path"]; exists {
+		staticPath = val
+	}
+
 	config := WatchdogConfig{
 		TCPPort:          getInt(envMap, "port", 8080),
 		HTTPReadTimeout:  getDuration(envMap, "read_timeout", time.Second*10),
 		HTTPWriteTimeout: getDuration(envMap, "write_timeout", time.Second*10),
 		FunctionProcess:  functionProcess,
+		StaticPath:       staticPath,
 		InjectCGIHeaders: true,
 		ExecTimeout:      getDuration(envMap, "exec_timeout", time.Second*10),
 		OperationalMode:  ModeStreaming,
@@ -94,7 +101,7 @@ func New(env []string) (WatchdogConfig, error) {
 		config.OperationalMode = WatchdogModeConst(val)
 	}
 
-	return config, nil
+	return config
 }
 
 func mapEnv(env []string) map[string]string {

--- a/config/config_modes.go
+++ b/config/config_modes.go
@@ -10,8 +10,11 @@ const (
 	// ModeAfterBurn for performance tuning
 	ModeAfterBurn = 3
 
-	//ModeHTTP for routing requests over HTTP
+	// ModeHTTP for routing requests over HTTP
 	ModeHTTP = 4
+
+	// ModeStatic for serving static content
+	ModeStatic = 5
 )
 
 // WatchdogModeConst as a const int
@@ -25,6 +28,8 @@ func WatchdogModeConst(mode string) int {
 		return ModeSerializing
 	case "http":
 		return ModeHTTP
+	case "static":
+		return ModeStatic
 	default:
 		return 0
 	}
@@ -41,6 +46,8 @@ func WatchdogMode(mode int) string {
 		return "serializing"
 	case ModeHTTP:
 		return "http"
+	case ModeStatic:
+		return "static"
 	default:
 		return "unknown"
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,20 +6,14 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	defaults, err := New([]string{})
-	if err != nil {
-		t.Errorf("Expected no errors")
-	}
+	defaults := New([]string{})
 	if defaults.TCPPort != 8080 {
 		t.Errorf("Want TCPPort: 8080, got: %d", defaults.TCPPort)
 	}
 }
 
 func Test_OperationalMode_Default(t *testing.T) {
-	defaults, err := New([]string{})
-	if err != nil {
-		t.Errorf("Expected no errors")
-	}
+	defaults := New([]string{})
 	if defaults.OperationalMode != ModeStreaming {
 		t.Errorf("Want %s. got: %s", WatchdogMode(ModeStreaming), WatchdogMode(defaults.OperationalMode))
 	}
@@ -27,10 +21,7 @@ func Test_OperationalMode_Default(t *testing.T) {
 func Test_BufferHttpModeDefaultsToFalse(t *testing.T) {
 	env := []string{}
 
-	actual, err := New(env)
-	if err != nil {
-		t.Errorf("Expected no errors")
-	}
+	actual := New(env)
 	want := false
 	if actual.BufferHTTPBody != want {
 		t.Errorf("Want %v. got: %v", want, actual.BufferHTTPBody)
@@ -42,10 +33,7 @@ func Test_BufferHttpMode_CanBeSetToTrue(t *testing.T) {
 		"buffer_http=true",
 	}
 
-	actual, err := New(env)
-	if err != nil {
-		t.Errorf("Expected no errors")
-	}
+	actual := New(env)
 	want := true
 	if actual.BufferHTTPBody != want {
 		t.Errorf("Want %v. got: %v", want, actual.BufferHTTPBody)
@@ -57,23 +45,29 @@ func Test_OperationalMode_AfterBurn(t *testing.T) {
 		"mode=afterburn",
 	}
 
-	actual, err := New(env)
-	if err != nil {
-		t.Errorf("Expected no errors")
-	}
+	actual := New(env)
 
 	if actual.OperationalMode != ModeAfterBurn {
 		t.Errorf("Want %s. got: %s", WatchdogMode(ModeAfterBurn), WatchdogMode(actual.OperationalMode))
 	}
 }
 
+func Test_OperationalMode_Static(t *testing.T) {
+	env := []string{
+		"mode=static",
+	}
+
+	actual := New(env)
+
+	if actual.OperationalMode != ModeStatic {
+		t.Errorf("Want %s. got: %s", WatchdogMode(ModeStatic), WatchdogMode(actual.OperationalMode))
+	}
+}
+
 func Test_ContentType_Default(t *testing.T) {
 	env := []string{}
 
-	actual, err := New(env)
-	if err != nil {
-		t.Errorf("Expected no errors")
-	}
+	actual := New(env)
 
 	if actual.ContentType != "application/octet-stream" {
 		t.Errorf("Default (ContentType) Want %s. got: %s", actual.ContentType, "octet-stream")
@@ -85,10 +79,7 @@ func Test_ContentType_Override(t *testing.T) {
 		"content_type=application/json",
 	}
 
-	actual, err := New(env)
-	if err != nil {
-		t.Errorf("Expected no errors")
-	}
+	actual := New(env)
 
 	if actual.ContentType != "application/json" {
 		t.Errorf("(ContentType) Want %s. got: %s", actual.ContentType, "application/json")
@@ -100,10 +91,7 @@ func Test_FunctionProcessLegacyName(t *testing.T) {
 		"fprocess=env",
 	}
 
-	actual, err := New(env)
-	if err != nil {
-		t.Errorf("Expected no errors")
-	}
+	actual := New(env)
 
 	if actual.FunctionProcess != "env" {
 		t.Errorf("Want %s. got: %s", "env", actual.FunctionProcess)
@@ -115,10 +103,7 @@ func Test_FunctionProcessAlternativeName(t *testing.T) {
 		"function_process=env",
 	}
 
-	actual, err := New(env)
-	if err != nil {
-		t.Errorf("Expected no errors")
-	}
+	actual := New(env)
 
 	if actual.FunctionProcess != "env" {
 		t.Errorf("Want %s. got: %s", "env", actual.FunctionProcess)
@@ -161,10 +146,7 @@ func Test_FunctionProcess_Arguments(t *testing.T) {
 
 	for _, testCase := range cases {
 		t.Run(testCase.scenario, func(t *testing.T) {
-			actual, err := New([]string{testCase.env})
-			if err != nil {
-				t.Errorf("Expected no errors")
-			}
+			actual := New([]string{testCase.env})
 
 			process, args := actual.Process()
 			if process != testCase.wantProcess {
@@ -192,10 +174,7 @@ func Test_PortOverride(t *testing.T) {
 		"port=8081",
 	}
 
-	actual, err := New(env)
-	if err != nil {
-		t.Errorf("Expected no errors")
-	}
+	actual := New(env)
 
 	if actual.TCPPort != 8081 {
 		t.Errorf("Want %d. got: %d", 8081, actual.TCPPort)
@@ -241,10 +220,7 @@ func Test_Timeouts(t *testing.T) {
 	}
 
 	for _, testCase := range cases {
-		actual, err := New(testCase.env)
-		if err != nil {
-			t.Errorf("(%s) Expected no errors", testCase.name)
-		}
+		actual := New(testCase.env)
 		if testCase.readTimeout != actual.HTTPReadTimeout {
 			t.Errorf("(%s) HTTPReadTimeout want: %s, got: %s", testCase.name, actual.HTTPReadTimeout, testCase.readTimeout)
 		}


### PR DESCRIPTION
This mode allows the users to use the watchdog as a static server for
serving static files. The added benefit over a plain file server is that
they get the RED metrics already implemented by the watchdog.

Signed-off-by: Matias Pan <matias.pan26@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A new mode was added called `static`. When the users set this mode they must also set the `static_path` variable that will be the directory the user wants to serve. If none is set we default to `/home/app/public`.

I also changed the signature of the `config.New` function, it was returning an error but in the function we were never actually returning an error. I updated the tests with this new change. 

Closes #74 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
When creating the hugo template we noticed that instead of depending on an external static server we could implement this functionality in the watchdog.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
After making the changes I built the binary and tweaked the hugo template for using the watchdog instead of the static server. I then built my personal blog that uses this template and served it locally with:
```
$ docker run -p 8080:8080 -it matipan/blog-watchdog:debug
2019/08/10 23:44:50 Serving files at /home/server/public
2019/08/10 23:44:50 OperationalMode: static
2019/08/10 23:44:50 Timeouts: read: 10s, write: 10s hard: 10s.
2019/08/10 23:44:50 Listening on port: 8080
2019/08/10 23:44:50 Writing lock-file to: /tmp/.lock
2019/08/10 23:44:50 Metrics listening on port: 8081
```
You can see that the logs indicate we are making use of the new `static` mode. I then went to http://localhost:8080 and saw that the website was being properly rendered:
![of-watchdog](https://user-images.githubusercontent.com/8126891/62827879-d349a280-bbaf-11e9-812e-97f6404729c9.png)

I also executed `./build.sh` to make sure all of the binaries are being properly built:
<details><summary>Output of build.sh:</summary>

```
$ ./build.sh 
[+] Building 27.2s (17/17) FINISHED                                                                                                                                                                                
 => [internal] load .dockerignore                                                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                                                               0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                          0.0s
 => => transferring dockerfile: 1.11kB                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/golang:1.10                                                                                                                                                2.2s
 => [1/12] FROM docker.io/library/golang:1.10@sha256:6d5e79878a3e4f1b30b7aa4d24fb6ee6184e905a9b172fc72593935633be4c46                                                                                         0.0s
 => [internal] load build context                                                                                                                                                                             0.0s
 => => transferring context: 1.01MB                                                                                                                                                                           0.0s
 => CACHED [2/12] RUN mkdir -p /go/src/github.com/openfaas-incubator/of-watchdog                                                                                                                              0.0s
 => CACHED [3/12] WORKDIR /go/src/github.com/openfaas-incubator/of-watchdog                                                                                                                                   0.0s
 => CACHED [4/12] COPY vendor              vendor                                                                                                                                                             0.0s
 => [5/12] COPY config              config                                                                                                                                                                    0.0s
 => [6/12] COPY executor            executor                                                                                                                                                                  0.0s
 => [7/12] COPY metrics             metrics                                                                                                                                                                   0.0s
 => [8/12] COPY metrics             metrics                                                                                                                                                                   0.0s
 => [9/12] COPY main.go             .                                                                                                                                                                         0.0s
 => [10/12] RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))"                                                                                                                  0.4s
 => [11/12] RUN go test -v ./...                                                                                                                                                                              2.3s
 => [12/12] RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-s -w" -installsuffix cgo -o of-watchdog .     && CGO_ENABLED=0 GOOS=darwin go build -a -ldflags "-s -w" -installsuffix cgo -o of-watchdog-d  21.2s
 => exporting to image                                                                                                                                                                                        0.8s 
 => => exporting layers                                                                                                                                                                                       0.8s 
 => => writing image sha256:47d8f0eb00de161216117c6c4b252c7fa9aff831cf7e14717097f410bd9e2970                                                                                                                  0.0s 
 => => naming to docker.io/openfaas/of-watchdog:build                                                                                                                                                         0.0s 
[+] Building 0.2s (6/6) FINISHED                                                                                                                                                                                   
 => [internal] load build definition from Dockerfile.packager                                                                                                                                                 0.0s
 => => transferring dockerfile: 223B                                                                                                                                                                          0.0s
 => [internal] load .dockerignore                                                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/openfaas/of-watchdog:build                                                                                                                                         0.0s
 => [build 1/1] FROM docker.io/openfaas/of-watchdog:build                                                                                                                                                     0.0s
 => => resolve docker.io/openfaas/of-watchdog:build                                                                                                                                                           0.0s
 => [stage-1 1/1] COPY --from=build /go/src/github.com/openfaas-incubator/of-watchdog/of-watchdog ./fwatchdog                                                                                                 0.0s
 => exporting to image                                                                                                                                                                                        0.1s
 => => exporting layers                                                                                                                                                                                       0.1s
 => => writing image sha256:d371050872a22e51571683749fb3c213091ab6bb2b02def46680509d20af3da2                                                                                                                  0.0s
 => => naming to docker.io/openfaas/of-watchdog:latest-dev-darwin                                                                                                                                             0.0s
[+] Building 0.1s (6/6) FINISHED                                                                                                                                                                                   
 => [internal] load .dockerignore                                                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                                                               0.0s
 => [internal] load build definition from Dockerfile.packager                                                                                                                                                 0.0s
 => => transferring dockerfile: 47B                                                                                                                                                                           0.0s
 => [internal] load metadata for docker.io/openfaas/of-watchdog:build                                                                                                                                         0.0s
 => CACHED [build 1/1] FROM docker.io/openfaas/of-watchdog:build                                                                                                                                              0.0s
 => [stage-1 1/1] COPY --from=build /go/src/github.com/openfaas-incubator/of-watchdog/of-watchdog ./fwatchdog                                                                                                 0.0s
 => exporting to image                                                                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                                                                       0.0s
 => => writing image sha256:d5620b3ac0dfea9df2f38d1b51b0a0d6210548d18cb576bbe021ccd63fefa945                                                                                                                  0.0s
 => => naming to docker.io/openfaas/of-watchdog:latest-dev-armhf                                                                                                                                              0.0s
[+] Building 0.2s (6/6) FINISHED                                                                                                                                                                                   
 => [internal] load build definition from Dockerfile.packager                                                                                                                                                 0.0s
 => => transferring dockerfile: 47B                                                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/openfaas/of-watchdog:build                                                                                                                                         0.0s
 => CACHED [build 1/1] FROM docker.io/openfaas/of-watchdog:build                                                                                                                                              0.0s
 => [stage-1 1/1] COPY --from=build /go/src/github.com/openfaas-incubator/of-watchdog/of-watchdog ./fwatchdog                                                                                                 0.0s
 => exporting to image                                                                                                                                                                                        0.1s
 => => exporting layers                                                                                                                                                                                       0.1s
 => => writing image sha256:b6f1615845a8b4c669efe8d0c71c978120d8a374770b1453d0ac351fde42f01d                                                                                                                  0.0s
 => => naming to docker.io/openfaas/of-watchdog:latest-dev-arm64                                                                                                                                              0.0s
[+] Building 0.2s (6/6) FINISHED                                                                                                                                                                                   
 => [internal] load build definition from Dockerfile.packager                                                                                                                                                 0.0s
 => => transferring dockerfile: 47B                                                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/openfaas/of-watchdog:build                                                                                                                                         0.0s
 => CACHED [build 1/1] FROM docker.io/openfaas/of-watchdog:build                                                                                                                                              0.0s
 => [stage-1 1/1] COPY --from=build /go/src/github.com/openfaas-incubator/of-watchdog/of-watchdog ./fwatchdog                                                                                                 0.0s
 => exporting to image                                                                                                                                                                                        0.1s
 => => exporting layers                                                                                                                                                                                       0.1s
 => => writing image sha256:a55312cdda8c3f2218df4880b15a0fc0c820fba4ac0327b1638476b6b006c404                                                                                                                  0.0s
 => => naming to docker.io/openfaas/of-watchdog:latest-dev-windows                                                                                                                                            0.0s
[+] Building 0.2s (6/6) FINISHED                                                                                                                                                                                   
 => [internal] load build definition from Dockerfile.packager                                                                                                                                                 0.0s
 => => transferring dockerfile: 47B                                                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/openfaas/of-watchdog:build                                                                                                                                         0.0s
 => CACHED [build 1/1] FROM docker.io/openfaas/of-watchdog:build                                                                                                                                              0.0s
 => [stage-1 1/1] COPY --from=build /go/src/github.com/openfaas-incubator/of-watchdog/of-watchdog ./fwatchdog                                                                                                 0.0s
 => exporting to image                                                                                                                                                                                        0.1s
 => => exporting layers                                                                                                                                                                                       0.0s
 => => writing image sha256:a4f46d41ea02ce6ab1f35d78295f4016ee95913e8082f08662a5edd4d34ceec0                                                                                                                  0.0s
 => => naming to docker.io/openfaas/of-watchdog:latest-dev-x86_64                                                                                                                                             0.0s
5bab7edf4e8eedaff0521f932eb5dad8dda4119dd970c39972f0121b316ff6d4
buildoutput
```

</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
