### PR TITLE
Make logging the forked process more transparent

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,5 +167,6 @@ Environmental variables:
 | `upstream_url`         | Yes          | `http` mode only - where to forward requests i.e. `127.0.0.1:5000` |
 | `buffer_http`     | Yes               | `http` mode only - buffers request body to memory before fowarding. Use if your upstream HTTP server does not accept `Transfer-Encoding: chunked` Default: `false` |
 | `max_inflight`    | Yes          | Limit the maximum number of requests in flight |
+| `log_buffer_size` | Yes          | Size in bytes of the buffer for reading log messages from the function_process |
 
 > Note: the .lock file is implemented for health-checking, but cannot be disabled yet. You must create this file in /tmp/.

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,10 @@ type WatchdogConfig struct {
 	UpstreamURL      string
 	StaticPath       string
 
+	// LogBufferSize is size of data that should be read from the logging
+	// pipes of the wrapped fprocess.
+	LogBufferSize int
+
 	// BufferHTTPBody buffers the HTTP body in memory
 	// to prevent transfer type of chunked encoding
 	// which some servers do not support.
@@ -92,6 +96,7 @@ func New(env []string) WatchdogConfig {
 		ContentType:      contentType,
 		SuppressLock:     getBool(envMap, "suppress_lock"),
 		UpstreamURL:      upstreamURL,
+		LogBufferSize:    getInt(envMap, "log_buffer_size", 16*1024),
 		BufferHTTPBody:   getBool(envMap, "buffer_http"),
 		MetricsPort:      8081,
 		MaxInflight:      getInt(envMap, "max_inflight", 0),

--- a/executor/afterburn_runner.go
+++ b/executor/afterburn_runner.go
@@ -2,23 +2,26 @@ package executor
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"os/exec"
 	"sync"
 )
 
 // AfterBurnFunctionRunner creates and maintains one process responsible for handling all calls
 type AfterBurnFunctionRunner struct {
-	Process     string
-	ProcessArgs []string
-	Command     *exec.Cmd
-	StdinPipe   io.WriteCloser
-	StdoutPipe  io.ReadCloser
-	Stderr      io.Writer
-	Mutex       sync.Mutex
+	Process       string
+	ProcessArgs   []string
+	Command       *exec.Cmd
+	StdinPipe     io.WriteCloser
+	StdoutPipe    io.ReadCloser
+	Stderr        io.Writer
+	LogBufferSize int
+	Mutex         sync.Mutex
 }
 
 // Start forks the process used for processing incoming requests
@@ -45,14 +48,14 @@ func (f *AfterBurnFunctionRunner) Start() error {
 	go func() {
 		log.Println("Started logging stderr from function.")
 		for {
-			errBuff := make([]byte, 256)
+			errBuff := make([]byte, f.LogBufferSize)
 
 			_, err := errPipe.Read(errBuff)
 			if err != nil {
 				log.Printf("Error reading stderr: %s", err)
 
 			} else {
-				log.Printf("stderr: %s", errBuff)
+				fmt.Fprintf(os.Stderr, "%s", errBuff)
 			}
 		}
 	}()

--- a/executor/afterburn_runner.go
+++ b/executor/afterburn_runner.go
@@ -50,12 +50,12 @@ func (f *AfterBurnFunctionRunner) Start() error {
 		for {
 			errBuff := make([]byte, f.LogBufferSize)
 
-			_, err := errPipe.Read(errBuff)
+			n, err := errPipe.Read(errBuff)
 			if err != nil {
 				log.Printf("Error reading stderr: %s", err)
 
 			} else {
-				fmt.Fprintf(os.Stderr, "%s", errBuff)
+				fmt.Fprintf(os.Stderr, "%s", string(errBuff[:n]))
 			}
 		}
 	}()

--- a/executor/http_runner.go
+++ b/executor/http_runner.go
@@ -28,6 +28,7 @@ type HTTPFunctionRunner struct {
 	StdinPipe      io.WriteCloser
 	StdoutPipe     io.ReadCloser
 	Stderr         io.Writer
+	LogBufferSize  int
 	Client         *http.Client
 	UpstreamURL    *url.URL
 	BufferHTTPBody bool
@@ -57,14 +58,14 @@ func (f *HTTPFunctionRunner) Start() error {
 	go func() {
 		log.Println("Started logging stderr from function.")
 		for {
-			errBuff := make([]byte, 256)
+			errBuff := make([]byte, f.LogBufferSize)
 
 			_, err := errPipe.Read(errBuff)
 			if err != nil {
 				log.Fatalf("Error reading stderr: %s", err)
 
 			} else {
-				log.Printf("stderr: %s", errBuff)
+				fmt.Fprintf(os.Stderr, "%s", errBuff)
 			}
 		}
 	}()
@@ -72,14 +73,14 @@ func (f *HTTPFunctionRunner) Start() error {
 	go func() {
 		log.Println("Started logging stdout from function.")
 		for {
-			errBuff := make([]byte, 256)
+			errBuff := make([]byte, f.LogBufferSize)
 
 			_, err := f.StdoutPipe.Read(errBuff)
 			if err != nil {
 				log.Fatalf("Error reading stdout: %s", err)
 
 			} else {
-				log.Printf("stdout: %s", errBuff)
+				fmt.Fprintf(os.Stdout, "%s", errBuff)
 			}
 		}
 	}()

--- a/executor/http_runner.go
+++ b/executor/http_runner.go
@@ -60,12 +60,12 @@ func (f *HTTPFunctionRunner) Start() error {
 		for {
 			errBuff := make([]byte, f.LogBufferSize)
 
-			_, err := errPipe.Read(errBuff)
+			n, err := errPipe.Read(errBuff)
 			if err != nil {
 				log.Fatalf("Error reading stderr: %s", err)
 
 			} else {
-				fmt.Fprintf(os.Stderr, "%s", errBuff)
+				fmt.Fprintf(os.Stderr, "%s", string(errBuff[:n]))
 			}
 		}
 	}()
@@ -75,12 +75,12 @@ func (f *HTTPFunctionRunner) Start() error {
 		for {
 			errBuff := make([]byte, f.LogBufferSize)
 
-			_, err := f.StdoutPipe.Read(errBuff)
+			n, err := f.StdoutPipe.Read(errBuff)
 			if err != nil {
 				log.Fatalf("Error reading stdout: %s", err)
 
 			} else {
-				fmt.Fprintf(os.Stdout, "%s", errBuff)
+				fmt.Fprintf(os.Stdout, "%s", string(errBuff[:n]))
 			}
 		}
 	}()

--- a/executor/streaming_runner.go
+++ b/executor/streaming_runner.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"os/exec"
 	"time"
 )
@@ -26,7 +27,8 @@ type FunctionRequest struct {
 
 // ForkFunctionRunner forks a process for each invocation
 type ForkFunctionRunner struct {
-	ExecTimeout time.Duration
+	ExecTimeout   time.Duration
+	LogBufferSize int
 }
 
 // Run run a fork for each invocation
@@ -68,7 +70,7 @@ func (f *ForkFunctionRunner) Run(req FunctionRequest) error {
 	go func() {
 		log.Println("Started logging stderr from function.")
 		for {
-			errBuff := make([]byte, 256)
+			errBuff := make([]byte, f.LogBufferSize)
 
 			n, err := errPipe.Read(errBuff)
 			if err != nil {
@@ -78,7 +80,7 @@ func (f *ForkFunctionRunner) Run(req FunctionRequest) error {
 				break
 			} else {
 				if n > 0 {
-					log.Printf("stderr: %s", errBuff)
+					fmt.Fprintf(os.Stderr, "%s", errBuff)
 				}
 			}
 		}

--- a/executor/streaming_runner.go
+++ b/executor/streaming_runner.go
@@ -80,7 +80,7 @@ func (f *ForkFunctionRunner) Run(req FunctionRequest) error {
 				break
 			} else {
 				if n > 0 {
-					fmt.Fprintf(os.Stderr, "%s", errBuff)
+					fmt.Fprintf(os.Stderr, "%s", string(errBuff[:n]))
 				}
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -176,8 +176,9 @@ func makeAfterBurnRequestHandler(watchdogConfig config.WatchdogConfig) func(http
 
 	commandName, arguments := watchdogConfig.Process()
 	functionInvoker := executor.AfterBurnFunctionRunner{
-		Process:     commandName,
-		ProcessArgs: arguments,
+		Process:       commandName,
+		ProcessArgs:   arguments,
+		LogBufferSize: watchdogConfig.LogBufferSize,
 	}
 
 	log.Printf("Forking %s %s\n", commandName, arguments)
@@ -238,7 +239,8 @@ func makeSerializingForkRequestHandler(watchdogConfig config.WatchdogConfig) fun
 
 func makeForkRequestHandler(watchdogConfig config.WatchdogConfig) func(http.ResponseWriter, *http.Request) {
 	functionInvoker := executor.ForkFunctionRunner{
-		ExecTimeout: watchdogConfig.ExecTimeout,
+		ExecTimeout:   watchdogConfig.ExecTimeout,
+		LogBufferSize: watchdogConfig.LogBufferSize,
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -298,6 +300,7 @@ func makeHTTPRequestHandler(watchdogConfig config.WatchdogConfig) func(http.Resp
 		Process:        commandName,
 		ProcessArgs:    arguments,
 		BufferHTTPBody: watchdogConfig.BufferHTTPBody,
+		LogBufferSize:  watchdogConfig.LogBufferSize,
 	}
 
 	if len(watchdogConfig.UpstreamURL) == 0 {


### PR DESCRIPTION
## Description
• Add a parameter to adjust the buffer size to be read from the wrapped function process `log_buffer_size`.
• Stdout as captured from the wrapped process is written to Stdout and Stderr is written to Stderr
• Lines are no longer managed by the watchdog and log formatting should be preserved from the output of the wrapped function process even if it exceeds a buffer boundary.

## Motivation and Context
The motivation of this PR was to address the issues raised in #75.

A quick encapsulation of the issues:
• Structured logging was being broken when it exceeded the buffer size.
• Stdout and err were being coalesced with a prefix making it difficult to parse.
• Watchdog logs were being interspersed with long output from the wrapped function process.

These can all largely be mitigated with a "big enough" buffer.  I've increased the default drastically to 16Kb and through the parameter `log_buffer_size` allowed users to choose their own buffer size.

## How Has This Been Tested?
I tested this using a [contrived http mode go function named `chatty-fn`](https://github.com/cconger/chatty-fn) that just logs requests that it receives and a bunch of other extra information.  I built the `chatty-fn` docker container and included different watchdogs to wrap it.  I then boot the docker container directly, and issue network requests directly to it.

```bash
# Within chatty-fn
docker build -t chatty-fn:latest .
docker run -p 8080:8080 chatty-fn:latest > stdout.log 2> stderr.log
curl -X POST localhost:8080 -H 'Content-Type: application/json' --data '{"hello": "world"}'
```

When built using the 0.5.3 of-watchdog it yields the following outputs:
**stdout.log**
```
Forking - /home/app/function []
```

**stderr.log**
```
2019/08/26 23:11:21 Started logging stderr from function.
2019/08/26 23:11:21 Started logging stdout from function.
2019/08/26 23:11:21 OperationalMode: http
2019/08/26 23:11:21 Writing lock-file to: /tmp/.lock
2019/08/26 23:11:21 Metrics server. Port: 8081
2019/08/26 23:11:21 stderr: Starting application server
������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������
2019/08/26 23:11:21 stdout: This is a warning to stdout
������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������
2019/08/26 23:11:28 stderr: Received request
�����������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������
2019/08/26 23:11:28 stdout: This is me writing to stdout on request: {"Method":"POST","URL":"/","Proto":"HTTP/1.1","Host":"localhost:8080","RemoteAddr":"127.0.0.1:51310","ContentLength":-1,"Body":"{\"hello\": \"world\"}","Headers":{"Accept":["*/*"],"Accept-Encoding":["gzip"],"Content
2019/08/26 23:11:28 stderr: Request: {"Method":"POST","URL":"/","Proto":"HTTP/1.1","Host":"localhost:8080","RemoteAddr":"127.0.0.1:51310","ContentLength":-1,"Body":"{\"hello\": \"world\"}","Headers":{"Accept":["*/*"],"Accept-Encoding":["gzip"],"Content-Type":["application/json"],"Use
2019/08/26 23:11:28 stdout: -Type":["application/json"],"User-Agent":["curl/7.54.0"]},"ReceivedAt":"2019-08-26T23:11:28.2348614Z"}
I liked what I got... so I'm gonna 200 OK
���������������������������������������������������������������������������������������������������������������
2019/08/26 23:11:28 stderr: r-Agent":["curl/7.54.0"]},"ReceivedAt":"2019-08-26T23:11:28.2348614Z"}
�����������������������������������������������������������������������������������������������������������������������������������������������������������������������������������������
2019/08/26 23:11:28 POST / - 200 OK - ContentLength: 2
```

When building with this branch the resulting log lines look like:
**stdout.log**
```
Forking - /home/app/function []
This is a warning to stdout
This is me writing to stdout on request: {"Method":"POST","URL":"/","Proto":"HTTP/1.1","Host":"localhost:8080","RemoteAddr":"127.0.0.1:51770","ContentLength":-1,"Body":"{\"hello\": \"world\"}","Headers":{"Accept":["*/*"],"Accept-Encoding":["gzip"],"Content-Type":["application/json"],"User-Agent":["curl/7.54.0"]},"ReceivedAt":"2019-08-26T23:12:44.5944136Z"}
I liked what I got... so I'm gonna 200 OK
```

**stderr.log**
```
2019/08/26 23:12:40 Started logging stdout from function.
2019/08/26 23:12:40 Started logging stderr from function.
2019/08/26 23:12:40 OperationalMode: http
2019/08/26 23:12:40 Timeouts: read: 10s, write: 10s hard: 10s.
2019/08/26 23:12:40 Listening on port: 8080
2019/08/26 23:12:40 Writing lock-file to: /tmp/.lock
2019/08/26 23:12:40 Metrics listening on port: 8081
Starting application server
Received request
Request: {"Method":"POST","URL":"/","Proto":"HTTP/1.1","Host":"localhost:8080","RemoteAddr":"127.0.0.1:51770","ContentLength":-1,"Body":"{\"hello\": \"world\"}","Headers":{"Accept":["*/*"],"Accept-Encoding":["gzip"],"Content-Type":["application/json"],"User-Agent":["curl/7.54.0"]},"ReceivedAt":"2019-08-26T23:12:44.5944136Z"}
2019/08/26 23:12:44 POST / - 200 OK - ContentLength: 2
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
