### PR TITLE
Adds a prefix of the file of origin to log lines from the fprocess

### DIFF
--- a/executor/logging.go
+++ b/executor/logging.go
@@ -15,7 +15,7 @@ func bindLoggingPipe(name string, pipe io.Reader, output io.Writer) {
 
 	go func() {
 		for scanner.Scan() {
-			logger.Println(scanner.Text())
+			logger.Printf("%s: %s", name, scanner.Text())
 		}
 		if err := scanner.Err(); err != nil {
 			log.Printf("Error scanning %s: %s", name, err.Error())


### PR DESCRIPTION
## Description
Adds a prefix of `stderr:` or `stdout:` to log lines from the wrapped function process.  This is important because the kubernetes log driver collapses stdout and stderr to a single collated file.

## Motivation and Context
This is an offshoot of our discussion on #73, which removed these prefixes in favor of piping to two different files (stderr and stdout).  The discussion can be seen [here](https://github.com/openfaas-incubator/of-watchdog/pull/73#issuecomment-526366294)

The discussion itself was a offshoot of #75 

## How Has This Been Tested?
Tested by creating another version of [`chatty-fn`](https://github.com/cconger/chatty-fn) built with a local dev base of `of-watchdog`

The image I used can be run: [`cconger/chatty-fn:prefixed`](https://cloud.docker.com/repository/docker/cconger/chatty-fn)

I have invoked the function directly to yield the following outputs:
**stdout.log**
```
Forking - /home/app/function []
2019/08/29 21:38:30 stdout: This is a warning to stdout
2019/08/29 21:38:32 stdout: This is me writing to stdout on request: {"Method":"POST","URL":"/","Proto":"HTTP/1.1","Host":"localhost:8080","RemoteAddr":"127.0.0.1:52092","ContentLength":-1,"Body":"{\"hello\": \"world\"}","Headers":{"Accept":["*/*"],"Accept-Encoding":["gzip"],"Content-Type":["application/json"],"User-Agent":["curl/7.54.0"]},"ReceivedAt":"2019-08-29T21:38:32.764158Z"}
2019/08/29 21:38:32 stdout: I liked what I got... so I'm gonna 200 OK
```

**stderr.log**
```
2019/08/29 21:38:30 Started logging stderr from function.
2019/08/29 21:38:30 Started logging stdout from function.
2019/08/29 21:38:30 OperationalMode: http
2019/08/29 21:38:30 Timeouts: read: 10s, write: 10s hard: 10s.
2019/08/29 21:38:30 Listening on port: 8080
2019/08/29 21:38:30 Writing lock-file to: /tmp/.lock
2019/08/29 21:38:30 Metrics listening on port: 8081
2019/08/29 21:38:30 stderr: Starting application server
2019/08/29 21:38:32 stderr: Received request
2019/08/29 21:38:32 stderr: Request: {"Method":"POST","URL":"/","Proto":"HTTP/1.1","Host":"localhost:8080","RemoteAddr":"127.0.0.1:52092","ContentLength":-1,"Body":"{\"hello\": \"world\"}","Headers":{"Accept":["*/*"],"Accept-Encoding":["gzip"],"Content-Type":["application/json"],"User-Agent":["curl/7.54.0"]},"ReceivedAt":"2019-08-29T21:38:32.764158Z"}
2019/08/29 21:38:32 POST / - 200 OK - ContentLength: 2
```

Also through faas log:
**faas logs logger-prefixed --instance=false --name=false**
```
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
2019-08-29T21:50:29Z Forking - /home/app/function []
2019-08-29T21:50:29Z 2019/08/29 21:50:29 Started logging stderr from function.
2019-08-29T21:50:29Z 2019/08/29 21:50:29 Started logging stdout from function.
2019-08-29T21:50:29Z 2019/08/29 21:50:29 OperationalMode: http
2019-08-29T21:50:29Z 2019/08/29 21:50:29 Timeouts: read: 10s, write: 10s hard: 10s.
2019-08-29T21:50:29Z 2019/08/29 21:50:29 Listening on port: 8080
2019-08-29T21:50:29Z 2019/08/29 21:50:29 Writing lock-file to: /tmp/.lock
2019-08-29T21:50:29Z 2019/08/29 21:50:29 Metrics listening on port: 8081
2019-08-29T21:50:29Z 2019/08/29 21:50:29 stdout: This is a warning to stdout
2019-08-29T21:50:29Z 2019/08/29 21:50:29 stderr: Starting application server
2019-08-29T21:50:37Z 2019/08/29 21:50:37 stderr: Received request
2019-08-29T21:50:37Z 2019/08/29 21:50:37 stderr: Request: {"Method":"POST","URL":"/","Proto":"HTTP/1.1","Host":"logger-prefixed.openfaas-fn.svc.cluster.local:8080","RemoteAddr":"127.0.0.1:35656","ContentLength":-1,"Body":"{\"hello\": \"world\"}","Headers":{"Accept":["application/json, text/plain, */*"],"Accept-Encoding":["gzip, deflate, br"],"Accept-Language":["en-US,en;q=0.9"],"Content-Type":["application/json"],"Origin":["http://localhost:31112"],"Referer":["http://localhost:31112/ui/"],"Sec-Fetch-Mode":["cors"],"Sec-Fetch-Site":["same-origin"],"User-Agent":["Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36"],"X-Call-Id":["296da232-10de-4382-864c-4f740d726f74"],"X-Forwarded-For":["192.168.65.3:47902"],"X-Forwarded-Host":["localhost:31112"],"X-Start-Time":["1567115437620376000"]},"ReceivedAt":"2019-08-29T21:50:37.6261213Z"}
2019-08-29T21:50:37Z 2019/08/29 21:50:37 stdout: This is me writing to stdout on request: {"Method":"POST","URL":"/","Proto":"HTTP/1.1","Host":"logger-prefixed.openfaas-fn.svc.cluster.local:8080","RemoteAddr":"127.0.0.1:35656","ContentLength":-1,"Body":"{\"hello\": \"world\"}","Headers":{"Accept":["application/json, text/plain, */*"],"Accept-Encoding":["gzip, deflate, br"],"Accept-Language":["en-US,en;q=0.9"],"Content-Type":["application/json"],"Origin":["http://localhost:31112"],"Referer":["http://localhost:31112/ui/"],"Sec-Fetch-Mode":["cors"],"Sec-Fetch-Site":["same-origin"],"User-Agent":["Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36"],"X-Call-Id":["296da232-10de-4382-864c-4f740d726f74"],"X-Forwarded-For":["192.168.65.3:47902"],"X-Forwarded-Host":["localhost:31112"],"X-Start-Time":["1567115437620376000"]},"ReceivedAt":"2019-08-29T21:50:37.6261213Z"}
2019-08-29T21:50:37Z 2019/08/29 21:50:37 stdout: I liked what I got... so I'm gonna 200 OK
2019-08-29T21:50:37Z 2019/08/29 21:50:37 POST / - 200 OK - ContentLength: 2
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
Arguably an un-breaking change as it returns functionality that was previously expected.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
