### PR TITLE
Add `healthcheck` subcommand.

### DIFF
--- a/main.go
+++ b/main.go
@@ -177,11 +177,19 @@ func buildRequestHandler(watchdogConfig config.WatchdogConfig) http.Handler {
 func createLockFile() (string, error) {
 	path := filepath.Join(os.TempDir(), ".lock")
 	log.Printf("Writing lock-file to: %s\n", path)
+
+	mkdirErr := os.MkdirAll(os.TempDir(), os.ModePerm)
+	if mkdirErr != nil {
+		return path, mkdirErr
+	}
+
 	writeErr := ioutil.WriteFile(path, []byte{}, 0660)
+	if writeErr != nil {
+		return path, writeErr
+	}
 
 	atomic.StoreInt32(&acceptingConnections, 1)
-
-	return path, writeErr
+	return path, nil
 }
 
 func makeAfterBurnRequestHandler(watchdogConfig config.WatchdogConfig) func(http.ResponseWriter, *http.Request) {

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -26,13 +27,24 @@ var (
 )
 
 func main() {
+	flag.Parse()
+
+	switch flag.Arg(0) {
+	case "healthcheck":
+		if lockFilePresent() {
+			os.Exit(0)
+		}
+
+		os.Exit(1)
+	}
+
 	atomic.StoreInt32(&acceptingConnections, 0)
 
 	watchdogConfig := config.New(os.Environ())
 
 	if len(watchdogConfig.FunctionProcess) == 0 && watchdogConfig.OperationalMode != config.ModeStatic {
 		fmt.Fprintf(os.Stderr, "Provide a \"function_process\" or \"fprocess\" environmental variable for your function.\n")
-		os.Exit(-1)
+		os.Exit(1)
 	}
 
 	requestHandler := buildRequestHandler(watchdogConfig)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Implements and closes https://github.com/openfaas-incubator/of-watchdog/issues/86.

## Motivation and Context

Explained in https://github.com/openfaas-incubator/of-watchdog/issues/86.

- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?

This was tested using a static website template:

```dockerfile
FROM alpine as tempdir

RUN mkdir -p /tempdir

FROM scratch

COPY --from=openfaas/of-watchdog:latest-dev-x86_64 /fwatchdog /fwatchdog
COPY --from=tempdir /tempdir /tmp

WORKDIR /home/app

COPY public public

HEALTHCHECK --interval=2s CMD ["/fwatchdog", "healthcheck"]

ENV mode="static"

CMD ["/fwatchdog"]
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
