### PR TITLE
Allow Int values and parse as Seconds for Durations

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -127,14 +127,26 @@ func mapEnv(env []string) map[string]string {
 }
 
 func getDuration(env map[string]string, key string, defaultValue time.Duration) time.Duration {
-	result := defaultValue
 	if val, exists := env[key]; exists {
-		parsed, _ := time.ParseDuration(val)
-		result = parsed
-
+		return parseIntOrDurationValue(val, defaultValue)
 	}
 
-	return result
+	return defaultValue
+}
+
+func parseIntOrDurationValue(val string, fallback time.Duration) time.Duration {
+	if len(val) > 0 {
+		parsedVal, parseErr := strconv.Atoi(val)
+		if parseErr == nil && parsedVal >= 0 {
+			return time.Duration(parsedVal) * time.Second
+		}
+	}
+
+	duration, durationErr := time.ParseDuration(val)
+	if durationErr != nil {
+		return fallback
+	}
+	return duration
 }
 
 func getInt(env map[string]string, key string, defaultValue int) int {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -262,3 +262,88 @@ func Test_Timeouts(t *testing.T) {
 	}
 
 }
+
+func Test_TestNonDurationValue_getDuration(t *testing.T) {
+	want := 10 * time.Second
+	env := map[string]string{"time": "10"}
+	got := getDuration(env, "time", 5*time.Second)
+
+	if want != got {
+		t.Error(fmt.Sprintf("want: %q got: %q", want, got))
+	}
+}
+
+func Test_TestDurationValue_getDuration(t *testing.T) {
+	want := 10 * time.Second
+	env := map[string]string{"time": "10s"}
+	got := getDuration(env, "time", 5*time.Second)
+
+	if want != got {
+		t.Error(fmt.Sprintf("want: %q got: %q", want, got))
+	}
+}
+func Test_TestNonParsableValue_getDuration(t *testing.T) {
+	want := 5 * time.Second
+	env := map[string]string{"time": "this is bad"}
+	got := getDuration(env, "time", 5*time.Second)
+
+	if want != got {
+		t.Error(fmt.Sprintf("want: %q got: %q", want, got))
+	}
+}
+
+func Test_TestMissingMapValue_getDuration(t *testing.T) {
+	want := 5 * time.Second
+	env := map[string]string{"time_is_missing": "10"}
+	got := getDuration(env, "time", 5*time.Second)
+
+	if want != got {
+		t.Error(fmt.Sprintf("want: %q got: %q", want, got))
+	}
+}
+
+func Test_IntAsString_parseIntOrDurationValue(t *testing.T) {
+	want := 10 * time.Second
+
+	got := parseIntOrDurationValue("10", 5*time.Second)
+	if want != got {
+		t.Error(fmt.Sprintf("want: %q got: %q", want, got))
+	}
+}
+
+func Test_Duration_parseIntOrDurationValue(t *testing.T) {
+	want := 10 * time.Second
+
+	got := parseIntOrDurationValue("10s", 5*time.Second)
+	if want != got {
+		t.Error(fmt.Sprintf("want: %q got: %q", want, got))
+	}
+
+}
+
+func Test_EmptyString_parseIntOrDurationValue(t *testing.T) {
+	want := 5 * time.Second
+
+	got := parseIntOrDurationValue("", 5*time.Second)
+	if want != got {
+		t.Error(fmt.Sprintf("want: %q got: %q", want, got))
+	}
+}
+
+func Test_ZeroAsString_parseIntOrDurationValue(t *testing.T) {
+	want := 0 * time.Second
+
+	got := parseIntOrDurationValue("0", 5*time.Second)
+	if want != got {
+		t.Error(fmt.Sprintf("want: %q got: %q", want, got))
+	}
+}
+
+func Test_NonParsableString_parseIntOrDurationValue(t *testing.T) {
+	want := 5 * time.Second
+
+	got := parseIntOrDurationValue("this is not good", 5*time.Second)
+	if want != got {
+		t.Error(fmt.Sprintf("want: %q got: %q", want, got))
+	}
+}


### PR DESCRIPTION
## Description
The timeout values could be accidentally set as ints by a user
rather than golang durations. This meant that "5" gets parsed
to 0s not 5s. Now we try and parse non duration strings as
seconds.

This has been tested by creating a function with the old binary,
setting the timeouts for read, write and exec to "5" and 5.
These are interpreted as 0s.

New binary swapped in and re-deployed, this then worked as our
waits were less than the 5 seconds, when expanded over 5s (the waits)
then the fn was stopped

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->
Fixes #64 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
#64 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This has been tested by creating a function with the old binary,
setting the timeouts for read, write and exec to "5" and 5.
These are interpreted as 0s.

New binary swapped in and re-deployed, this then worked as our
waits were less than the 5 seconds, when expanded over 5s (the waits)
then the fn was stopped


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
