### PR TITLE
Fix some logic of config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -101,7 +101,7 @@ func New(env []string) WatchdogConfig {
 		MaxInflight:      getInt(envMap, "max_inflight", 0),
 	}
 
-	if val := envMap["mode"]; len(val) > 0 {
+	if val, exists := envMap["mode"]; exists {
 		config.OperationalMode = WatchdogModeConst(val)
 	}
 
@@ -113,7 +113,7 @@ func mapEnv(env []string) map[string]string {
 
 	for _, val := range env {
 		keyValue := strings.SplitN(val, "=", 2)
-		if len(keyValue) == 2 {
+		if len(keyValue) == 2 && keyValue[1] != "" {
 			mapped[keyValue[0]] = keyValue[1]
 			continue
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -45,7 +45,7 @@ func (w WatchdogConfig) Process() (string, []string) {
 		return parts[0], parts[1:]
 	}
 
-	return parts[0], []string{}
+	return parts[0], nil
 }
 
 // New create config based upon environmental variables.

--- a/config/config.go
+++ b/config/config.go
@@ -112,7 +112,7 @@ func mapEnv(env []string) map[string]string {
 	mapped := map[string]string{}
 
 	for _, val := range env {
-		keyValue := strings.Split(val, "=")
+		keyValue := strings.SplitN(val, "=", 2)
 		if len(keyValue) == 2 {
 			mapped[keyValue[0]] = keyValue[1]
 			continue

--- a/config/config.go
+++ b/config/config.go
@@ -112,17 +112,13 @@ func mapEnv(env []string) map[string]string {
 	mapped := map[string]string{}
 
 	for _, val := range env {
-		sep := strings.Index(val, "=")
-
-		if sep > 0 {
-			key := val[0:sep]
-			value := val[sep+1:]
-			mapped[key] = value
-		} else {
-			fmt.Println("Bad environment: " + val)
+		keyValue := strings.Split(val, "=")
+		if len(keyValue) == 2 {
+			mapped[keyValue[0]] = keyValue[1]
+			continue
 		}
+		fmt.Println("Bad environment: " + val)
 	}
-
 	return mapped
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -345,5 +346,58 @@ func Test_NonParsableString_parseIntOrDurationValue(t *testing.T) {
 	got := parseIntOrDurationValue("this is not good", 5*time.Second)
 	if want != got {
 		t.Error(fmt.Sprintf("want: %q got: %q", want, got))
+	}
+}
+
+func Test_mapEnv(t *testing.T) {
+	type args struct {
+		env []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+	}{
+		{
+			name: "change env to map",
+			args: args{
+				env: []string{
+					"FOO=BAR",
+				},
+			},
+			want: map[string]string{
+				"FOO": "BAR",
+			},
+		},
+		{
+			name: "keep '=' of environment value when contains '='",
+			args: args{
+				env: []string{
+					"FOO=BAR=BAZ",
+				},
+			},
+			want: map[string]string{
+				"FOO": "BAR=BAZ",
+			},
+		},
+		{
+			name: "ignore empty value environment",
+			args: args{
+				env: []string{
+					"FOO=",
+					"BAR=BAZ",
+				},
+			},
+			want: map[string]string{
+				"BAR": "BAZ",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mapEnv(tt.args.env); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("mapEnv() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

1. change second part of WatchdogConfig.Process's response to nil rather than an empty slice.
2. change the logic of mapEnv and ignore empty value environment

 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

1. original Process will return a 0 length empty slice, By changing that into a nil will prevent unnecessary alloc.
2. empty value environment is useless for building a config.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

go test -run Test_mapEnv

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
